### PR TITLE
fix: null ref crash in PlayerLeftRoom on server shutdown

### DIFF
--- a/src/Tapestry.Server/GameLoopService.cs
+++ b/src/Tapestry.Server/GameLoopService.cs
@@ -84,11 +84,11 @@ public class GameLoopService : IHostedService
             _sessions.Remove(session);
             _metrics.ActiveConnections.Add(-1);
 
-            if (session.PlayerEntity.LocationRoomId != null)
+            if (lastRoomId != null)
             {
-                var room = _world.GetRoom(session.PlayerEntity.LocationRoomId);
+                var room = _world.GetRoom(lastRoomId);
                 room?.RemoveEntity(session.PlayerEntity);
-                _mobAI.PlayerLeftRoom(session.PlayerEntity.LocationRoomId);
+                _mobAI.PlayerLeftRoom(lastRoomId);
             }
 
             _world.UntrackEntity(session.PlayerEntity);


### PR DESCRIPTION
## Summary

- RemoveEntity clears LocationRoomId on the entity
- Second reference to session.PlayerEntity.LocationRoomId inside the if block was null by the time PlayerLeftRoom was called
- Fixed to use the already-captured lastRoomId variable instead

Repros on clean server shutdown when all sessions disconnect.

## Test plan
- [x] Start server, connect, shut down cleanly -- no null ref crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)