### PR TITLE
Deploy: Droplet infrastructure + client auto-connect

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,30 @@ on:
     tags: ['v*']
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+      client: ${{ steps.filter.outputs.client }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            server:
+              - 'src/**'
+              - 'packs/**'
+              - 'Dockerfile'
+              - '*.yaml'
+              - '*.csproj'
+              - '*.slnx'
+            client:
+              - 'client/**'
+
+  deploy-server:
+    needs: changes
+    if: needs.changes.outputs.server == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,3 +52,46 @@ jobs:
           tags: |
             ghcr.io/tapestry-mud/tapestry:latest
             ghcr.io/tapestry-mud/tapestry:${{ github.sha }}
+
+      # Phase 1 only: deploy to Droplet when example-pack is the active server.
+      # When LF becomes the active server, remove this step or set the
+      # DEPLOY_ENABLED repository variable to "false" to skip it.
+      - name: Deploy to Droplet
+        if: github.ref == 'refs/heads/master' && vars.DEPLOY_ENABLED != 'false'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: 165.22.230.43
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd /opt/tapestry
+            docker compose pull game-server
+            docker compose up -d game-server
+
+  deploy-client:
+    needs: changes
+    if: needs.changes.outputs.client == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build client
+        working-directory: client
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy client to Droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: 165.22.230.43
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "client/dist/"
+          target: /opt/tapestry/client
+          strip_components: 1

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -14,7 +14,6 @@ import { useLayoutStore } from '../stores/layoutStore'
 import { useAffectsStore } from '../stores/affectsStore'
 import { useCombatTargetStore } from '../stores/combatTargetStore'
 import { useCombatTargetsStore } from '../stores/combatTargetsStore'
-import { getTerminal } from '../terminal/terminalStore'
 import {
   CharVitalsSchema, CharStatusSchema, CharExperienceSchema, CharCommandsSchema,
   CharEffectsSchema, CharCombatTargetSchema, CharCombatTargetsSchema, CharItemsSchema,

--- a/client/src/connection/WebSocketClient.ts
+++ b/client/src/connection/WebSocketClient.ts
@@ -11,6 +11,15 @@ let reconnectAttempt = 0
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let shouldReconnect = false
 
+function deriveServerUrl(): string | null {
+  const { hostname, host, protocol } = window.location
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return null
+  }
+  const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${wsProtocol}//${host}/ws`
+}
+
 function connect(address: string): void {
   const url = address.startsWith('ws') ? address : `ws://${address}`
   useConnectionStore.getState().setServerAddress(address)
@@ -87,4 +96,4 @@ function sendGmcp(pkg: string, data: unknown): void {
   useDebugStore.getState().logGmcp(pkg, data, 'out')
 }
 
-export const WebSocketClient = { connect, disconnect, send, sendGmcp }
+export const WebSocketClient = { connect, disconnect, send, sendGmcp, deriveServerUrl }

--- a/client/src/layout/ConnectScreen.test.tsx
+++ b/client/src/layout/ConnectScreen.test.tsx
@@ -4,8 +4,9 @@ import { ConnectScreen } from './ConnectScreen'
 import { useConnectionStore } from '../stores/connectionStore'
 
 const mockConnect = vi.hoisted(() => vi.fn())
+const mockDeriveServerUrl = vi.hoisted(() => vi.fn().mockReturnValue(null))
 vi.mock('../connection/WebSocketClient', () => ({
-  WebSocketClient: { connect: mockConnect },
+  WebSocketClient: { connect: mockConnect, deriveServerUrl: mockDeriveServerUrl },
 }))
 
 beforeEach(() => {

--- a/client/src/layout/ConnectScreen.tsx
+++ b/client/src/layout/ConnectScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { WebSocketClient } from '../connection/WebSocketClient'
 import { useConnectionStore } from '../stores/connectionStore'
 
@@ -24,8 +24,20 @@ export function ConnectScreen() {
   const { status, error } = useConnectionStore()
   const [address, setAddress] = useState(() => localStorage.getItem(LAST_KEY) ?? '')
   const [recent, setRecent] = useState<string[]>(loadRecent)
+  const [autoConnectAttempted, setAutoConnectAttempted] = useState(false)
 
   const isConnecting = status === 'connecting'
+
+  useEffect(() => {
+    if (autoConnectAttempted) {
+      return
+    }
+    const autoUrl = WebSocketClient.deriveServerUrl()
+    if (autoUrl) {
+      setAutoConnectAttempted(true)
+      WebSocketClient.connect(autoUrl)
+    }
+  }, [autoConnectAttempted])
 
   function connect() {
     const addr = address.trim()
@@ -33,6 +45,18 @@ export function ConnectScreen() {
     saveRecent(addr)
     setRecent(loadRecent())
     WebSocketClient.connect(addr)
+  }
+
+  // If auto-connecting, show a minimal connecting screen
+  const autoUrl = WebSocketClient.deriveServerUrl()
+  if (autoUrl && (status === 'connecting' || status === 'connected')) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-surface">
+        <div className="bg-surface-raised border border-border rounded-lg p-8 w-80 flex flex-col gap-4">
+          <h1 className="text-text-primary text-xl font-bold font-ui text-center">Connecting...</h1>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/client/src/panels/EquipmentPanel.tsx
+++ b/client/src/panels/EquipmentPanel.tsx
@@ -37,8 +37,8 @@ export function EquipmentPanel() {
       <div className="font-mono text-xs">
         {sortedKeys.map((key) => {
           const item = slots[key]
-          const raritySegs = item?.rarityTag ? renderTags(item.rarityTag, colorMap) : []
-          const essenceSegs = item?.essenceTag ? renderTags(item.essenceTag, colorMap) : []
+          const raritySegs = item?.rarity ? renderTags(item.rarity, colorMap) : []
+          const essenceSegs = item?.essence ? renderTags(item.essence, colorMap) : []
           return (
             <div key={key} className="flex items-baseline py-0.5 gap-1">
               <span className="text-text-secondary w-20 shrink-0 text-right">[{slotLabel(key)}]</span>

--- a/client/src/panels/InventoryPanel.tsx
+++ b/client/src/panels/InventoryPanel.tsx
@@ -15,8 +15,8 @@ export function InventoryPanel() {
       ) : (
         <ul className="flex flex-col gap-0.5">
           {items.map((item) => {
-            const raritySegs = item.rarityTag ? renderTags(item.rarityTag, colorMap) : []
-            const essenceSegs = item.essenceTag ? renderTags(item.essenceTag, colorMap) : []
+            const raritySegs = item.rarity ? renderTags(item.rarity, colorMap) : []
+            const essenceSegs = item.essence ? renderTags(item.essence, colorMap) : []
             return (
               <li key={item.id} className="flex items-baseline gap-1 text-xs font-mono">
                 {raritySegs.length > 0 && (

--- a/client/src/panels/RoomPanel.tsx
+++ b/client/src/panels/RoomPanel.tsx
@@ -5,7 +5,7 @@ import type { RoomNode } from '../types/game'
 const MAP_RADIUS = 2
 const CELL_SIZE = 10
 
-function MiniMap({ graph, currentNum }: { graph: Map<number, RoomNode>; currentNum: number }) {
+function MiniMap({ graph, currentNum }: { graph: Map<string, RoomNode>; currentNum: string }) {
   const current = graph.get(currentNum)
   if (!current) { return <div className="w-24 h-24 bg-surface rounded" /> }
 

--- a/client/src/stores/layoutStore.ts
+++ b/client/src/stores/layoutStore.ts
@@ -39,7 +39,7 @@ interface LayoutState {
   resetLayout: () => void
 }
 
-export const useLayoutStore = create<LayoutState>()((set, get) => ({
+export const useLayoutStore = create<LayoutState>()((set) => ({
   panels: DEFAULT_PANELS,
 
   loadLayoutForCharacter: (charName) => {

--- a/client/src/stores/roomStore.ts
+++ b/client/src/stores/roomStore.ts
@@ -36,7 +36,7 @@ function mapStorageKey(charName: string): string {
   return `tapestry:map:${charName}`
 }
 
-function saveMapToStorage(charName: string, graph: Map<number, RoomNode>): void {
+function saveMapToStorage(charName: string, graph: Map<string, RoomNode>): void {
   if (!charName) { return }
   localStorage.setItem(mapStorageKey(charName), JSON.stringify([...graph.entries()]))
 }

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -28,5 +28,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts"]
 }


### PR DESCRIPTION
## Summary

- Add path-filtered CI/CD: server changes build+deploy Docker image, client changes build+deploy static files
- Web client auto-connects when served from a production domain (skips connect screen)
- Fix pre-existing TypeScript build errors so `npm run build` succeeds
- Exclude test files from production TypeScript build

## Deploy details

- Uses `appleboy/ssh-action` and `appleboy/scp-action` for Droplet deploy
- Server deploy gated by `DEPLOY_ENABLED` repo variable (for Phase 2 LF switchover)
- Client deploy uses `scp-action` to copy `dist/` to Droplet

## Test plan

- [x] Web client builds successfully (`npm run build`)
- [x] Client tests pass (277/277)
- [x] Droplet live at https://lf.demome.com with TLS, telnet, and websocket working
- [x] Auto-connect works on production domain, connect screen preserved on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)