### PR TITLE
fix: restore rarityTag/essenceTag in client panels

### DIFF
--- a/client/src/panels/EquipmentPanel.tsx
+++ b/client/src/panels/EquipmentPanel.tsx
@@ -37,8 +37,8 @@ export function EquipmentPanel() {
       <div className="font-mono text-xs">
         {sortedKeys.map((key) => {
           const item = slots[key]
-          const raritySegs = item?.rarity ? renderTags(item.rarity, colorMap) : []
-          const essenceSegs = item?.essence ? renderTags(item.essence, colorMap) : []
+          const raritySegs = item?.rarityTag ? renderTags(item.rarityTag, colorMap) : []
+          const essenceSegs = item?.essenceTag ? renderTags(item.essenceTag, colorMap) : []
           return (
             <div key={key} className="flex items-baseline py-0.5 gap-1">
               <span className="text-text-secondary w-20 shrink-0 text-right">[{slotLabel(key)}]</span>

--- a/client/src/panels/InventoryPanel.tsx
+++ b/client/src/panels/InventoryPanel.tsx
@@ -15,8 +15,8 @@ export function InventoryPanel() {
       ) : (
         <ul className="flex flex-col gap-0.5">
           {items.map((item) => {
-            const raritySegs = item.rarity ? renderTags(item.rarity, colorMap) : []
-            const essenceSegs = item.essence ? renderTags(item.essence, colorMap) : []
+            const raritySegs = item.rarityTag ? renderTags(item.rarityTag, colorMap) : []
+            const essenceSegs = item.essenceTag ? renderTags(item.essenceTag, colorMap) : []
             return (
               <li key={item.id} className="flex items-baseline gap-1 text-xs font-mono">
                 {raritySegs.length > 0 && (

--- a/client/src/stores/equipmentStore.ts
+++ b/client/src/stores/equipmentStore.ts
@@ -5,6 +5,8 @@ interface EquipmentSlot {
   name: string
   rarity?: string
   essence?: string
+  rarityTag?: string
+  essenceTag?: string
 }
 
 interface EquipmentState {

--- a/client/src/types/game.ts
+++ b/client/src/types/game.ts
@@ -49,6 +49,8 @@ export interface Item {
   templateId?: string
   rarity?: string
   essence?: string
+  rarityTag?: string
+  essenceTag?: string
 }
 
 export interface HotbarSlot {


### PR DESCRIPTION
## Summary
- Restores `rarityTag`/`essenceTag` field access in EquipmentPanel and InventoryPanel
- Adds missing `rarityTag`/`essenceTag` fields to TypeScript interfaces (EquipmentSlot, Item)
- The server sends decorated tag strings (e.g. `<item.rare>Rare</item.rare>`) via these GMCP fields -- a previous build fix incorrectly swapped them for the plain `rarity`/`essence` fields, breaking colored display

## Test plan
- [ ] Connect to lf.demome.com after deploy
- [ ] Equip a rare item -- rarity tag should display with color
- [ ] Check inventory for items with essence tags -- should display with color

🤖 Generated with [Claude Code](https://claude.com/claude-code)