### PR TITLE
fix: screen reader overhaul based on NVDA testing

### DIFF
--- a/client/src/accessibility/SkipLinks.tsx
+++ b/client/src/accessibility/SkipLinks.tsx
@@ -1,7 +1,21 @@
+import { useEffect, useRef } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useAnnounceStore } from './announceStore'
 
 export function SkipLinks() {
   const openSettings = useSettingsStore((s) => s.openSettings)
+  const announced = useRef(false)
+
+  useEffect(() => {
+    if (announced.current) { return }
+    announced.current = true
+    setTimeout(() => {
+      useAnnounceStore.getState().pushMessage(
+        'Tapestry game loaded. Press F6 to cycle between command input and game panels.',
+        'polite'
+      )
+    }, 1000)
+  }, [])
 
   function handleAnnounceSettings(e: React.MouseEvent | React.KeyboardEvent) {
     e.preventDefault()
@@ -13,12 +27,6 @@ export function SkipLinks() {
 
   return (
     <nav aria-label="Skip links" className="sr-only focus-within:not-sr-only focus-within:fixed focus-within:top-0 focus-within:left-0 focus-within:z-50 focus-within:flex focus-within:gap-2 focus-within:p-2 focus-within:bg-surface-deep">
-      <a
-        href="#game-output"
-        className="bg-accent text-white px-3 py-1.5 rounded text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
-      >
-        Skip to game output
-      </a>
       <a
         href="#command-input"
         className="bg-accent text-white px-3 py-1.5 rounded text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -112,7 +112,11 @@ export function initCoreHandlers(): void {
   GmcpDispatcher.register('Char.Combat.Target', (data) => {
     const result = CharCombatTargetSchema.safeParse(data)
     if (result.success) {
+      const prev = useCombatTargetStore.getState()
       useCombatTargetStore.getState().update(result.data)
+      if (result.data.active && result.data.healthTier && result.data.healthTier !== prev.healthTier) {
+        announce(`${result.data.name}: ${result.data.healthText ?? result.data.healthTier}`, 'combat', 'polite')
+      }
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Char.Combat.Target')
     }
@@ -137,6 +141,9 @@ export function initCoreHandlers(): void {
     const result = RoomInfoSchema.safeParse(data)
     if (result.success) {
       useRoomStore.getState().updateRoom(result.data)
+      const exits = Object.keys(result.data.exits)
+      const exitStr = exits.length > 0 ? `, exits: ${exits.join(', ')}` : ', no exits'
+      announce(`${result.data.name}${exitStr}`, 'room')
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Room.Info')
     }

--- a/client/src/hooks/useLandmarkCycling.ts
+++ b/client/src/hooks/useLandmarkCycling.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+const LANDMARK_IDS = ['command-input', 'left-panels', 'right-panels']
+
+export function useLandmarkCycling() {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'F6') { return }
+      e.preventDefault()
+
+      const activeId = document.activeElement?.closest('[id]')?.id ?? ''
+      const currentIndex = LANDMARK_IDS.indexOf(activeId)
+      const nextIndex = (currentIndex + 1) % LANDMARK_IDS.length
+      const target = document.getElementById(LANDMARK_IDS[nextIndex])
+
+      if (target) {
+        const focusable = target.querySelector<HTMLElement>('input, button, [tabindex="0"]')
+        if (focusable) {
+          focusable.focus()
+        } else {
+          target.focus()
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => { window.removeEventListener('keydown', handleKeyDown) }
+  }, [])
+}

--- a/client/src/layout/GameLayout.tsx
+++ b/client/src/layout/GameLayout.tsx
@@ -9,6 +9,7 @@ import { TopBar } from './TopBar'
 import { SortablePanel } from './SortablePanel'
 import { useLayoutStore } from '../stores/layoutStore'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useLandmarkCycling } from '../hooks/useLandmarkCycling'
 import { Announcer } from '../accessibility/Announcer'
 import { SkipLinks } from '../accessibility/SkipLinks'
 import { CharacterPanel }   from '../panels/CharacterPanel'
@@ -50,6 +51,7 @@ export function GameLayout() {
   const { panels, setPanelColumn, setPanelOrder } = useLayoutStore()
   const [activeId, setActiveId] = useState<string | null>(null)
   const isMobile = useIsMobile()
+  useLandmarkCycling()
 
   const leftPanels  = panels.filter((p) => p.column === 'left').sort((a, b) => a.order - b.order)
   const rightPanels = panels.filter((p) => p.column === 'right').sort((a, b) => a.order - b.order)
@@ -114,6 +116,7 @@ export function GameLayout() {
 
               <Panel defaultSize="25%" minSize="15%" maxSize="40%"
                 className="flex flex-col overflow-y-auto border-r border-border gap-1 p-1">
+                <div id="left-panels" tabIndex={-1} role="complementary" aria-label="Left game panels" className="flex flex-col gap-1 outline-none">
                 <SortableContext items={leftPanels.map((p) => p.id)} strategy={verticalListSortingStrategy}>
                   {leftPanels.map((p) => {
                     const Component = PANEL_COMPONENTS[p.id]
@@ -125,6 +128,7 @@ export function GameLayout() {
                     )
                   })}
                 </SortableContext>
+                </div>
               </Panel>
 
               <PanelResizeHandle className="w-1 bg-border hover:bg-accent cursor-col-resize transition-colors" />
@@ -139,6 +143,7 @@ export function GameLayout() {
 
               <Panel defaultSize="25%" minSize="15%" maxSize="40%"
                 className="flex flex-col overflow-y-auto border-l border-border gap-1 p-1">
+                <div id="right-panels" tabIndex={-1} role="complementary" aria-label="Right game panels" className="flex flex-col gap-1 outline-none">
                 <SortableContext items={rightPanels.map((p) => p.id)} strategy={verticalListSortingStrategy}>
                   {rightPanels.map((p) => {
                     const Component = PANEL_COMPONENTS[p.id]
@@ -150,6 +155,7 @@ export function GameLayout() {
                     )
                   })}
                 </SortableContext>
+                </div>
               </Panel>
 
             </PanelGroup>

--- a/client/src/panels/OutputViewport.tsx
+++ b/client/src/panels/OutputViewport.tsx
@@ -16,7 +16,7 @@ export function OutputViewport() {
       cursorBlink: false,
       cursorStyle: 'bar',
       disableStdin: true,
-      screenReaderMode: true,
+      screenReaderMode: false,
       scrollback: 5000,
       fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
       fontSize: 14,
@@ -74,8 +74,8 @@ export function OutputViewport() {
   }
 
   return (
-    <div id="game-output" className="relative flex-1 overflow-hidden bg-surface-deep pl-3" role="log" aria-label="Game output">
-      <div ref={containerRef} className="h-full w-full" />
+    <div id="game-output" className="relative flex-1 overflow-hidden bg-surface-deep pl-3" aria-hidden="true">
+      <div ref={containerRef} className="h-full w-full" tabIndex={-1} />
       {scrolledUp && (
         <button
           onClick={scrollToBottom}

--- a/client/src/panels/RoomViewPanel.tsx
+++ b/client/src/panels/RoomViewPanel.tsx
@@ -11,7 +11,7 @@ export function RoomViewPanel() {
   const exitCount = exits.length
 
   return (
-    <div className="px-4 py-3 font-mono text-sm border-b border-border shrink-0 bg-surface-raised">
+    <div className="px-4 py-3 font-mono text-sm border-b border-border shrink-0 bg-surface-raised" aria-hidden="true">
       <div className="text-yellow-400 font-bold mb-0.5">{current.name}</div>
       {current.area && (
         <div className="text-text-secondary text-[10px] uppercase tracking-wider mb-2">


### PR DESCRIPTION
## Summary

Follow-up to #33 after real NVDA testing revealed `screenReaderMode` is wrong for a MUD. Replaces the "read everything" model with curated announcements.

- Disable xterm `screenReaderMode` (prompt spam, double room reads, combat unreadable)
- Terminal and RoomViewPanel now `aria-hidden` (sighted-only elements)
- Room changes announced via GMCP announcer: concise "Room Name, exits: north, south"
- Combat target health tier changes announced only on tier shift
- F6 landmark cycling between command input and panel columns
- One-time welcome announcement with F6 hint on game load
- Remove "skip to game output" skip link (terminal hidden from screen readers)

## Test Plan

- [ ] NVDA: verify no terminal output is read aloud
- [ ] NVDA: verify room announcement on movement
- [ ] NVDA: verify combat target tier change announced
- [ ] NVDA: F6 cycles between command input, left panels, right panels
- [ ] NVDA: welcome message announced on load
- [ ] Sighted: verify zero visual changes
- [ ] Verify xterm click does not trap keyboard focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)