### PR TITLE
feat: GMCP accessibility for login and character creation flows

### DIFF
--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -274,7 +274,7 @@ export function initCoreHandlers(): void {
         const optionLines = options.map((o, i) =>
           o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`
         )
-        announce(`${prompt} ${optionLines.join('. ')}. Type ? and a number for details.`, 'prompt')
+        announce(`${prompt} ${optionLines.join('. ')}. Type question mark and a number for details.`, 'prompt')
       } else {
         announce(prompt, 'prompt')
       }

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -22,7 +22,7 @@ import {
   CharEquipmentSchema,
   RoomInfoSchema, RoomNearbySchema,
   WorldTimeSchema, WorldWeatherSchema, WorldDisplayColorsSchema, CommChannelSchema, LoginPhaseSchema,
-  LoginPromptSchema, FlowStepSchema,
+  LoginPromptSchema, FlowStepSchema, FlowHelpSchema,
 } from '../types/gmcp'
 import {
   ResponseFeedbackSchema,
@@ -260,7 +260,7 @@ export function initCoreHandlers(): void {
   GmcpDispatcher.register('Login.Prompt', (data) => {
     const result = LoginPromptSchema.safeParse(data)
     if (result.success) {
-      announce(result.data.prompt, 'feedback')
+      announce(result.data.prompt, 'prompt')
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Login.Prompt')
     }
@@ -274,12 +274,21 @@ export function initCoreHandlers(): void {
         const optionLines = options.map((o, i) =>
           o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`
         )
-        announce(`${prompt} ${optionLines.join('. ')}`, 'feedback')
+        announce(`${prompt} ${optionLines.join('. ')}. Type ? and a number for details.`, 'prompt')
       } else {
-        announce(prompt, 'feedback')
+        announce(prompt, 'prompt')
       }
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Flow.Step')
+    }
+  })
+
+  GmcpDispatcher.register('Flow.Help', (data) => {
+    const result = FlowHelpSchema.safeParse(data)
+    if (result.success) {
+      announce(result.data.text, 'prompt')
+    } else {
+      useDebugStore.getState().logConnection('gmcp-parse-error', 'Flow.Help')
     }
   })
 

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -22,6 +22,7 @@ import {
   CharEquipmentSchema,
   RoomInfoSchema, RoomNearbySchema,
   WorldTimeSchema, WorldWeatherSchema, WorldDisplayColorsSchema, CommChannelSchema, LoginPhaseSchema,
+  LoginPromptSchema, FlowStepSchema,
 } from '../types/gmcp'
 import {
   ResponseFeedbackSchema,
@@ -253,6 +254,31 @@ export function initCoreHandlers(): void {
       useConnectionStore.getState().setLoginPhase(result.data.phase)
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Char.Login.Phase')
+    }
+  })
+
+  GmcpDispatcher.register('Login.Prompt', (data) => {
+    const result = LoginPromptSchema.safeParse(data)
+    if (result.success) {
+      announce(result.data.prompt, 'feedback')
+    } else {
+      useDebugStore.getState().logConnection('gmcp-parse-error', 'Login.Prompt')
+    }
+  })
+
+  GmcpDispatcher.register('Flow.Step', (data) => {
+    const result = FlowStepSchema.safeParse(data)
+    if (result.success) {
+      const { type, prompt, options } = result.data
+      announce(prompt, 'feedback')
+      if (type === 'choice' && options && options.length > 0) {
+        const optionText = options
+          .map((o, i) => o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`)
+          .join(', ')
+        announce(optionText, 'feedback')
+      }
+    } else {
+      useDebugStore.getState().logConnection('gmcp-parse-error', 'Flow.Step')
     }
   })
 

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -272,10 +272,10 @@ export function initCoreHandlers(): void {
       const { type, prompt, options } = result.data
       announce(prompt, 'feedback')
       if (type === 'choice' && options && options.length > 0) {
-        const optionText = options
-          .map((o, i) => o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`)
-          .join(', ')
-        announce(optionText, 'feedback')
+        options.forEach((o, i) => {
+          const text = o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`
+          announce(text, 'feedback')
+        })
       }
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Flow.Step')

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -270,12 +270,13 @@ export function initCoreHandlers(): void {
     const result = FlowStepSchema.safeParse(data)
     if (result.success) {
       const { type, prompt, options } = result.data
-      announce(prompt, 'feedback')
       if (type === 'choice' && options && options.length > 0) {
-        options.forEach((o, i) => {
-          const text = o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`
-          announce(text, 'feedback')
-        })
+        const optionLines = options.map((o, i) =>
+          o.tagLine ? `${i + 1}. ${o.label}: ${o.tagLine}` : `${i + 1}. ${o.label}`
+        )
+        announce(`${prompt} ${optionLines.join('. ')}`, 'feedback')
+      } else {
+        announce(prompt, 'feedback')
       }
     } else {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Flow.Step')

--- a/client/src/controls/CommandBar.tsx
+++ b/client/src/controls/CommandBar.tsx
@@ -87,6 +87,7 @@ export function CommandBar() {
         className={`w-2.5 h-2.5 rounded-full shrink-0 ${STATUS_COLOR[status] ?? 'bg-border'}`}
       />
       <input
+        key={isPassword ? 'password' : 'text'}
         id="command-input"
         ref={inputRef}
         type={isPassword ? 'password' : 'text'}

--- a/client/src/controls/CommandBar.tsx
+++ b/client/src/controls/CommandBar.tsx
@@ -87,7 +87,7 @@ export function CommandBar() {
         className={`w-2.5 h-2.5 rounded-full shrink-0 ${STATUS_COLOR[status] ?? 'bg-border'}`}
       />
       <input
-        key={isPassword ? 'password' : 'text'}
+        key={loginPhase ?? 'disconnected'}
         id="command-input"
         ref={inputRef}
         type={isPassword ? 'password' : 'text'}

--- a/client/src/controls/CommandBar.tsx
+++ b/client/src/controls/CommandBar.tsx
@@ -34,6 +34,10 @@ export function CommandBar() {
     inputRef.current?.focus()
   }, [pending, clearPending])
 
+  useEffect(() => {
+    if (!isPassword) { setValue('') }
+  }, [isPassword])
+
   function send() {
     const cmd = value.trim()
     if (!cmd) { return }

--- a/client/src/layout/LoginLayout.tsx
+++ b/client/src/layout/LoginLayout.tsx
@@ -1,10 +1,12 @@
 import { OutputViewport } from '../panels/OutputViewport'
 import { CommandBar } from '../controls/CommandBar'
 import { TopBar } from './TopBar'
+import { Announcer } from '../accessibility/Announcer'
 
 export function LoginLayout() {
   return (
     <div className="flex flex-col h-screen bg-surface text-text-primary">
+      <Announcer />
       <TopBar />
       <div className="flex flex-1 overflow-hidden justify-center">
         <div className="flex flex-col w-full max-w-3xl">

--- a/client/src/stores/announcePrefsStore.ts
+++ b/client/src/stores/announcePrefsStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 
 export type AnnouncePref = 'assertive' | 'polite' | 'off'
 
-export type AnnounceCategory = 'vitals' | 'chat' | 'combat' | 'room' | 'feedback'
+export type AnnounceCategory = 'vitals' | 'chat' | 'combat' | 'room' | 'feedback' | 'prompt'
 
 const STORAGE_KEY = 'tapestry:announce-prefs'
 
@@ -12,6 +12,7 @@ const DEFAULTS: Record<AnnounceCategory, AnnouncePref> = {
   combat: 'assertive',
   room: 'polite',
   feedback: 'polite',
+  prompt: 'assertive',
 }
 
 function loadPrefs(): Record<AnnounceCategory, AnnouncePref> {

--- a/client/src/types/gmcp.ts
+++ b/client/src/types/gmcp.ts
@@ -198,3 +198,8 @@ export const FlowStepSchema = z.object({
   })).optional(),
 })
 export type FlowStep = z.infer<typeof FlowStepSchema>
+
+export const FlowHelpSchema = z.object({
+  text: z.string(),
+})
+export type FlowHelp = z.infer<typeof FlowHelpSchema>

--- a/client/src/types/gmcp.ts
+++ b/client/src/types/gmcp.ts
@@ -183,3 +183,18 @@ export const LoginPhaseSchema = z.object({
 })
 export type LoginPhase = z.infer<typeof LoginPhaseSchema>['phase']
 export type LoginPhaseState = LoginPhase | 'disconnected'
+
+export const LoginPromptSchema = z.object({
+  prompt: z.string(),
+})
+export type LoginPrompt = z.infer<typeof LoginPromptSchema>
+
+export const FlowStepSchema = z.object({
+  type: z.enum(['info', 'choice', 'text', 'confirm']),
+  prompt: z.string(),
+  options: z.array(z.object({
+    label: z.string(),
+    tagLine: z.string().optional(),
+  })).optional(),
+})
+export type FlowStep = z.infer<typeof FlowStepSchema>

--- a/src/Tapestry.Engine/Flow/FlowEngine.cs
+++ b/src/Tapestry.Engine/Flow/FlowEngine.cs
@@ -26,6 +26,8 @@ public class FlowEngine
     /// TelnetService sets this on startup so stat defaults match initial creation.
     public Func<string, Entity>? NewPlayerEntityFactory { get; set; }
 
+    public Action<string, string, object>? GmcpSend { get; set; }
+
     public FlowEngine(
         FlowRegistry registry,
         SessionManager sessions,
@@ -57,6 +59,7 @@ public class FlowEngine
 
         var instance = new FlowInstance(definition, session.PlayerEntity, _panelRenderer);
         instance.OnCompleted = () => Complete(session);
+        instance.GmcpSend = GmcpSend;
         session.CurrentFlow = instance;
         _playerCreator.TrackEntity(session.PlayerEntity);
         instance.Start(session);

--- a/src/Tapestry.Engine/Flow/FlowInstance.cs
+++ b/src/Tapestry.Engine/Flow/FlowInstance.cs
@@ -13,6 +13,7 @@ public class FlowInstance
     private int _currentStepIndex;
 
     public Action? OnCompleted { get; set; }
+    public Action<string, string, object>? GmcpSend { get; set; }
     public FlowDefinition Definition => _definition;
     public Entity Entity => _entity;
     public int CurrentStepIndex => _currentStepIndex;
@@ -208,8 +209,11 @@ public class FlowInstance
         switch (step)
         {
             case InfoStep info:
+            {
                 _session!.SendLine(info.Text(_entity));
+                GmcpSend?.Invoke(_session.Connection.Id, "Flow.Step", new { type = "info", prompt = info.Text(_entity) });
                 break;
+            }
             case ChoiceStep choice:
             {
                 if (_definition.WizardSteps != null && _session!.Connection.SupportsAnsi)
@@ -226,18 +230,29 @@ public class FlowInstance
                     }
                     _session!.SendLine("  ? [option] or ? [number] for details");
                 }
+                var choiceOptions = choice.Options(_entity);
+                var choicePayload = choiceOptions.Select(o => o.TagLine != null
+                    ? (object)new { label = o.Label, tagLine = o.TagLine }
+                    : (object)new { label = o.Label }).ToArray();
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "choice", prompt = choice.Prompt(_entity), options = choicePayload });
                 break;
             }
             case TextStep text:
+            {
                 if (text.Secret)
                 {
                     _session!.Connection.SuppressEcho();
                 }
                 _session!.SendLine(text.Prompt(_entity));
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "text", prompt = text.Prompt(_entity) });
                 break;
+            }
             case ConfirmStep confirm:
+            {
                 _session!.SendLine($"{confirm.Prompt(_entity)} (y/n)");
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "confirm", prompt = $"{confirm.Prompt(_entity)} (y/n)" });
                 break;
+            }
         }
     }
 

--- a/src/Tapestry.Engine/Flow/FlowInstance.cs
+++ b/src/Tapestry.Engine/Flow/FlowInstance.cs
@@ -97,15 +97,21 @@ public class FlowInstance
 
             if (match == null)
             {
-                _session!.SendLine($"Unknown option: {helpTarget}");
+                var unknownText = $"Unknown option: {helpTarget}";
+                _session!.SendLine(unknownText);
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Help", new { text = unknownText });
             }
             else if (match.Description != null)
             {
-                _session!.SendLine(match.Description(_entity));
+                var descText = match.Description(_entity);
+                _session!.SendLine(descText);
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Help", new { text = descText });
             }
             else
             {
-                _session!.SendLine($"No additional information available for {match.Label}.");
+                var noInfoText = $"No additional information available for {match.Label}.";
+                _session!.SendLine(noInfoText);
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Help", new { text = noInfoText });
             }
             if (_definition.WizardSteps == null || !_session!.Connection.SupportsAnsi)
             {

--- a/src/Tapestry.Engine/Flow/FlowInstance.cs
+++ b/src/Tapestry.Engine/Flow/FlowInstance.cs
@@ -210,8 +210,9 @@ public class FlowInstance
         {
             case InfoStep info:
             {
-                _session!.SendLine(info.Text(_entity));
-                GmcpSend?.Invoke(_session.Connection.Id, "Flow.Step", new { type = "info", prompt = info.Text(_entity) });
+                var infoText = info.Text(_entity);
+                _session!.SendLine(infoText);
+                GmcpSend?.Invoke(_session.Connection.Id, "Flow.Step", new { type = "info", prompt = infoText });
                 break;
             }
             case ChoiceStep choice:
@@ -243,14 +244,16 @@ public class FlowInstance
                 {
                     _session!.Connection.SuppressEcho();
                 }
-                _session!.SendLine(text.Prompt(_entity));
-                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "text", prompt = text.Prompt(_entity) });
+                var textPrompt = text.Prompt(_entity);
+                _session!.SendLine(textPrompt);
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "text", prompt = textPrompt });
                 break;
             }
             case ConfirmStep confirm:
             {
-                _session!.SendLine($"{confirm.Prompt(_entity)} (y/n)");
-                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "confirm", prompt = $"{confirm.Prompt(_entity)} (y/n)" });
+                var confirmPrompt = confirm.Prompt(_entity);
+                _session!.SendLine($"{confirmPrompt} (y/n)");
+                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Step", new { type = "confirm", prompt = confirmPrompt });
                 break;
             }
         }

--- a/src/Tapestry.Server/ConnectionHandler.cs
+++ b/src/Tapestry.Server/ConnectionHandler.cs
@@ -60,7 +60,9 @@ public class ConnectionHandler
         _mobAI = mobAI;
         _flowEngine.NewPlayerEntityFactory = CreateNewPlayerEntity;
         _flowEngine.GmcpSend = (connectionId, package, payload) =>
+        {
             _gmcpService.SendRaw(connectionId, package, payload);
+        };
     }
 
     private static Entity CreateNewPlayerEntity(string name)

--- a/src/Tapestry.Server/ConnectionHandler.cs
+++ b/src/Tapestry.Server/ConnectionHandler.cs
@@ -187,6 +187,7 @@ public class ConnectionHandler
             if (string.IsNullOrWhiteSpace(name))
             {
                 connection.SendLine("Please enter a name.");
+                _gmcpService.SendLoginPrompt(rawConnection.Id, "Please enter a name.");
                 return;
             }
 
@@ -240,6 +241,7 @@ public class ConnectionHandler
                             return;
                         }
                         connection.SendLine("Incorrect password.");
+                        _gmcpService.SendLoginPrompt(rawConnection.Id, "Incorrect password.");
                         connection.SendLine("What is your name, adventurer?");
                         _gmcpService.SendLoginPhase(rawConnection.Id, "name");
                         _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");

--- a/src/Tapestry.Server/ConnectionHandler.cs
+++ b/src/Tapestry.Server/ConnectionHandler.cs
@@ -187,7 +187,7 @@ public class ConnectionHandler
             if (string.IsNullOrWhiteSpace(name))
             {
                 connection.SendLine("Please enter a name.");
-                _gmcpService.SendLoginPrompt(rawConnection.Id, "Please enter a name.");
+                _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                 return;
             }
 

--- a/src/Tapestry.Server/ConnectionHandler.cs
+++ b/src/Tapestry.Server/ConnectionHandler.cs
@@ -59,6 +59,8 @@ public class ConnectionHandler
         _gameLoop = gameLoop;
         _mobAI = mobAI;
         _flowEngine.NewPlayerEntityFactory = CreateNewPlayerEntity;
+        _flowEngine.GmcpSend = (connectionId, package, payload) =>
+            _gmcpService.SendRaw(connectionId, package, payload);
     }
 
     private static Entity CreateNewPlayerEntity(string name)
@@ -106,6 +108,7 @@ public class ConnectionHandler
         connection.SendLine("=== " + _config.Server.Name + " ===");
         connection.SendLine("");
         connection.SendLine("What is your name, adventurer?");
+        _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
 
         Action<string>? currentHandler = null;
 
@@ -189,6 +192,7 @@ public class ConnectionHandler
             {
                 connection.SendLine("Names must be 2-20 letters only.");
                 connection.SendLine("What is your name, adventurer?");
+                _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                 return;
             }
 
@@ -196,6 +200,7 @@ public class ConnectionHandler
             {
                 connection.SendLine("Someone else is creating that name right now. Try another.");
                 connection.SendLine("What is your name, adventurer?");
+                _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                 return;
             }
 
@@ -204,6 +209,7 @@ public class ConnectionHandler
                 _gmcpService.SendLoginPhase(rawConnection.Id, "password");
                 connection.SuppressEcho();
                 connection.SendLine("Password:");
+                _gmcpService.SendLoginPrompt(rawConnection.Id, "Password:");
 
                 SetHandler((passwordInput) =>
                 {
@@ -217,6 +223,7 @@ public class ConnectionHandler
                         connection.SendLine("Error loading character. Please try again.");
                         connection.SendLine("What is your name, adventurer?");
                         _gmcpService.SendLoginPhase(rawConnection.Id, "name");
+                        _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                         SetHandler(nameHandler);
                         return;
                     }
@@ -233,6 +240,7 @@ public class ConnectionHandler
                         connection.SendLine("Incorrect password.");
                         connection.SendLine("What is your name, adventurer?");
                         _gmcpService.SendLoginPhase(rawConnection.Id, "name");
+                        _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                         SetHandler(nameHandler);
                         return;
                     }
@@ -242,6 +250,7 @@ public class ConnectionHandler
                     {
                         _gmcpService.SendLoginPhase(rawConnection.Id, "name");
                         connection.SendLine("That character is already connected. Reconnect? (y/n)");
+                        _gmcpService.SendLoginPrompt(rawConnection.Id, "That character is already connected. Reconnect? (y/n)");
 
                         SetHandler((confirmInput) =>
                         {
@@ -260,6 +269,7 @@ public class ConnectionHandler
                             {
                                 connection.SendLine("What is your name, adventurer?");
                                 _gmcpService.SendLoginPhase(rawConnection.Id, "name");
+                                _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                                 SetHandler(nameHandler);
                             }
                         });
@@ -308,6 +318,7 @@ public class ConnectionHandler
                         return;
                     }
                     connection.SendLine("What is your name, adventurer?");
+                    _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                     return;
                 }
 
@@ -316,6 +327,7 @@ public class ConnectionHandler
                 _gmcpService.SendLoginPhase(rawConnection.Id, "password");
                 connection.SuppressEcho();
                 connection.SendLine("New character! Choose a password:");
+                _gmcpService.SendLoginPrompt(rawConnection.Id, "New character! Choose a password:");
 
                 Action<string> firstPasswordHandler = null!;
                 firstPasswordHandler = (passwordInput) =>
@@ -336,10 +348,12 @@ public class ConnectionHandler
                             $"Password must be at least {_config.Persistence.PasswordMinLength} characters.");
                         connection.SuppressEcho();
                         connection.SendLine("Choose a password:");
+                        _gmcpService.SendLoginPrompt(rawConnection.Id, "Choose a password:");
                         return;
                     }
 
                     connection.SendLine("Confirm password:");
+                    _gmcpService.SendLoginPrompt(rawConnection.Id, "Confirm password:");
                     SetHandler((confirmInput) =>
                     {
                         connection.SendLine("");
@@ -357,6 +371,7 @@ public class ConnectionHandler
                             connection.SendLine("Passwords don't match. Try again.");
                             connection.SuppressEcho();
                             connection.SendLine("Choose a password:");
+                            _gmcpService.SendLoginPrompt(rawConnection.Id, "Choose a password:");
                             SetHandler(firstPasswordHandler);
                             return;
                         }
@@ -385,6 +400,7 @@ public class ConnectionHandler
                         {
                             connection.SendLine("Someone else is creating that name right now. Try another.");
                             connection.SendLine("What is your name, adventurer?");
+                            _gmcpService.SendLoginPrompt(rawConnection.Id, "What is your name, adventurer?");
                             SetHandler(nameHandler);
                             return;
                         }

--- a/src/Tapestry.Server/GmcpService.cs
+++ b/src/Tapestry.Server/GmcpService.cs
@@ -262,6 +262,20 @@ public class GmcpService
         _handlers.TryRemove(connectionId, out _);
     }
 
+    public void SendRaw(string connectionId, string package, object payload)
+    {
+        if (!_handlers.TryGetValue(connectionId, out var handler)) { return; }
+        if (!handler.GmcpActive) { return; }
+        handler.Send(package, payload);
+    }
+
+    public void SendLoginPrompt(string connectionId, string prompt)
+    {
+        if (!_handlers.TryGetValue(connectionId, out var handler)) { return; }
+        if (!handler.GmcpActive) { return; }
+        handler.Send("Login.Prompt", new { prompt });
+    }
+
     public void SendLoginPhase(string connectionId, string phase)
     {
         if (!_handlers.TryGetValue(connectionId, out var handler)) { return; }


### PR DESCRIPTION
## Summary

- Emit `Login.Prompt` GMCP events alongside every login prompt (name, password, reconnect confirm) so screen readers can announce them
- Emit `Flow.Step` GMCP events for each character creation wizard step (info, choice, text, confirm) including prompt text and options
- Emit `Flow.Help` GMCP events when a player requests `? N` option details during the wizard
- Add `Announcer` component to `LoginLayout` so ARIA live regions are active during login/creation
- Add dedicated `prompt` announce category (assertive, not mutable) for required accessibility prompts
- Fix screen reader announcing `*` after password entry by keying the command input on `loginPhase` -- each phase transition creates a fresh DOM node with no cached mode

## What screen reader users can now do

- Hear every login prompt announced as they appear
- Hear the full character creation wizard including choice options and help details
- Transition into the game with a clean input element that the screen reader correctly identifies as a text field

## Test plan

- [x] Connect as a new player -- hear "What is your name, adventurer?" announced
- [x] Enter a name -- hear "New character! Choose a password:" announced
- [x] After password confirmation -- wizard choice steps announce prompt + numbered options + "Type question mark and a number for details"
- [x] Type `? 1` on a choice step -- hear the option description announced
- [x] Complete creation -- no star/asterisk artifacts announced when entering the game view
- [x] Connect as an existing player -- hear "Password:" announced; incorrect password re-announces the name prompt
- [x] Screen reader announces "Game command input" (text field, not password field) when focus lands on the command bar in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)