### PR TITLE
fix: mobile layout - terminal and command bar only

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>client-tmp</title>
+    <title>Tapestry</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/layout/GameLayout.tsx
+++ b/client/src/layout/GameLayout.tsx
@@ -98,9 +98,7 @@ export function GameLayout() {
       <main className="flex-1 overflow-hidden">
         {isMobile ? (
           <div className="flex flex-col h-full overflow-hidden">
-            <RoomViewPanel />
             <OutputViewport />
-            <Hotbar />
 
             <div className="sr-only" role="complementary" aria-label="Game panels">
               {allPanelIds.map((id) => {


### PR DESCRIPTION
## Summary

- Remove RoomViewPanel and Hotbar from mobile layout (< 768px)
- Mobile now shows only the xterm terminal and command bar, maximizing screen space when the on-screen keyboard is open
- Room info is already handled by the accessibility announcer on movement
- GMCP panels remain in the DOM as sr-only for screen readers

## Test Plan

- [ ] Mobile viewport (DevTools < 768px): only terminal and command bar visible
- [ ] On-screen keyboard leaves usable terminal space
- [ ] Room announcements still fire on movement
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)