### PR TITLE
fix: strip markup tags from Alt+L room description announcement

### DIFF
--- a/client/src/accessibility/shortcuts/roomDescription.test.ts
+++ b/client/src/accessibility/shortcuts/roomDescription.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { handleRoomDescription } from './roomDescription'
+import { handleRoomDescription, stripMarkup } from './roomDescription'
 import { useRoomStore } from '../../stores/roomStore'
 import { useAnnounceStore } from '../announceStore'
 
@@ -49,5 +49,72 @@ describe('handleRoomDescription', () => {
     handleRoomDescription()
     expect(pushSpy).toHaveBeenCalledWith('Hallway. A narrow hallway. No exits.', 'assertive')
     pushSpy.mockRestore()
+  })
+
+  it('strips ANSI escape codes from description before announcing', () => {
+    useRoomStore.setState({
+      current: {
+        ...nullRoom,
+        name: 'Dungeon',
+        description: '\x1b[1;32mA damp dungeon.\x1b[0m',
+        exits: {},
+      },
+    })
+    const pushSpy = vi.spyOn(useAnnounceStore.getState(), 'pushMessage')
+    handleRoomDescription()
+    expect(pushSpy).toHaveBeenCalledWith('Dungeon. A damp dungeon. No exits.', 'assertive')
+    pushSpy.mockRestore()
+  })
+
+  it('strips Tapestry color tags from description before announcing', () => {
+    useRoomStore.setState({
+      current: {
+        ...nullRoom,
+        name: 'Forest',
+        description: '{cyan}A dense forest.{reset}',
+        exits: { east: 'core:road' },
+      },
+    })
+    const pushSpy = vi.spyOn(useAnnounceStore.getState(), 'pushMessage')
+    handleRoomDescription()
+    expect(pushSpy).toHaveBeenCalledWith('Forest. A dense forest. Exits: east.', 'assertive')
+    pushSpy.mockRestore()
+  })
+
+  it('strips markup from name before announcing', () => {
+    useRoomStore.setState({
+      current: {
+        ...nullRoom,
+        name: '{bold}Town Square{reset}',
+        description: 'A busy square.',
+        exits: {},
+      },
+    })
+    const pushSpy = vi.spyOn(useAnnounceStore.getState(), 'pushMessage')
+    handleRoomDescription()
+    expect(pushSpy).toHaveBeenCalledWith('Town Square. A busy square. No exits.', 'assertive')
+    pushSpy.mockRestore()
+  })
+})
+
+describe('stripMarkup', () => {
+  it('removes ANSI escape sequences', () => {
+    expect(stripMarkup('\x1b[1;32mHello\x1b[0m')).toBe('Hello')
+  })
+
+  it('removes bare bracket-form ANSI sequences', () => {
+    expect(stripMarkup('[1mBold[0m')).toBe('Bold')
+  })
+
+  it('removes Tapestry color/style tags', () => {
+    expect(stripMarkup('{cyan}Hello{reset}')).toBe('Hello')
+  })
+
+  it('removes HTML-like tags', () => {
+    expect(stripMarkup('<b>Hello</b>')).toBe('Hello')
+  })
+
+  it('returns plain text unchanged', () => {
+    expect(stripMarkup('Just plain text.')).toBe('Just plain text.')
   })
 })

--- a/client/src/accessibility/shortcuts/roomDescription.ts
+++ b/client/src/accessibility/shortcuts/roomDescription.ts
@@ -1,11 +1,24 @@
 import { useRoomStore } from '../../stores/roomStore'
 import { useAnnounceStore } from '../announceStore'
 
+export function stripMarkup(text: string): string {
+  // Remove ANSI escape sequences: \x1b[...m or ESC[...m
+  let result = text.replace(/\x1b\[[0-9;]*m/g, '')
+  // Remove bare bracket-form ANSI sequences that slipped through: [0m, [1;32m, etc.
+  result = result.replace(/\[[0-9;]+m/g, '')
+  // Remove Tapestry color/style tags: {cyan}, {bold}, {reset}, etc.
+  result = result.replace(/\{[a-zA-Z0-9_]+\}/g, '')
+  // Remove any remaining HTML-like tags
+  result = result.replace(/<[^>]+>/g, '')
+  return result
+}
+
 export function handleRoomDescription(): void {
   const { current } = useRoomStore.getState()
   const exits = Object.keys(current.exits)
   const exitStr = exits.length > 0 ? `Exits: ${exits.join(', ')}.` : 'No exits.'
-  const desc = current.description.replace(/\.$/, '')
-  const text = `${current.name}. ${desc}. ${exitStr}`
+  const desc = stripMarkup(current.description).replace(/\.$/, '')
+  const name = stripMarkup(current.name)
+  const text = `${name}. ${desc}. ${exitStr}`
   useAnnounceStore.getState().pushMessage(text, 'assertive')
 }


### PR DESCRIPTION
## Summary

- Adds a pure `stripMarkup(text: string): string` helper in `roomDescription.ts` that removes ANSI escape sequences (`\x1b[...m` and bare `[...m` forms), Tapestry color/style tags (`{cyan}`, `{bold}`, `{reset}`, etc.), and any HTML-like tags
- Applies `stripMarkup` to both `current.name` and `current.description` before building the screen-reader announcement string
- Exports `stripMarkup` so it can be unit-tested and potentially reused by other accessibility helpers

Closes #41

## Test plan

- [x] Existing 3 tests still pass (no regression)
- [x] New test: ANSI escape codes stripped from description
- [x] New test: `{cyan}`-style Tapestry tags stripped from description
- [x] New test: markup stripped from room name
- [x] New `stripMarkup` unit tests cover all four markup forms (ANSI, bare-bracket ANSI, Tapestry tags, HTML-like tags) plus plain-text passthrough
- [x] `npm run test -- roomDescription` reports 11/11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)