### PR TITLE
feat: pack-driven help system with role filtering and chargen integration

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { useAffectsStore } from './stores/affectsStore'
 import { initCoreHandlers } from './connection/GmcpDispatcher'
 import { useShortcutStore } from './stores/shortcutStore'
 import { registerAllShortcuts } from './accessibility/shortcuts/registerAll'
+import { HelpModal } from './panels/HelpModal'
 
 initCoreHandlers()
 registerAllShortcuts()
@@ -52,7 +53,19 @@ export default function App() {
     return <ConnectScreen />
   }
   if (loginPhase === 'playing') {
-    return <GameLayout />
+    return (
+      <>
+        {/* Mounted at App level (not inside GameLayout) so it's available during chargen */}
+        <HelpModal />
+        <GameLayout />
+      </>
+    )
   }
-  return <LoginLayout />
+  return (
+    <>
+      {/* Mounted at App level (not inside GameLayout) so it's available during chargen */}
+      <HelpModal />
+      <LoginLayout />
+    </>
+  )
 }

--- a/client/src/accessibility/shortcuts/helpTopic.ts
+++ b/client/src/accessibility/shortcuts/helpTopic.ts
@@ -7,9 +7,7 @@ export function handleHelpTopic(): void {
   if (!isOpen || !response || response.status !== 'ok') { return }
   const topic = response.topic
   const parts: string[] = [topic.brief]
-  for (const s of topic.syntax) {
-    parts.push('Syntax: ' + s)
-  }
+  if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
   if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
   parts.push(topic.body)
   useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')

--- a/client/src/accessibility/shortcuts/helpTopic.ts
+++ b/client/src/accessibility/shortcuts/helpTopic.ts
@@ -1,0 +1,16 @@
+import { useHelpStore } from '../../stores/helpStore'
+import { useAnnounceStore } from '../announceStore'
+import { stripMarkup } from '../../utils/text'
+
+export function handleHelpTopic(): void {
+  const { response, isOpen } = useHelpStore.getState()
+  if (!isOpen || !response || response.status !== 'ok') { return }
+  const topic = response.topic
+  const parts: string[] = [topic.brief]
+  for (const s of topic.syntax) {
+    parts.push('Syntax: ' + s)
+  }
+  if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
+  parts.push(topic.body)
+  useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')
+}

--- a/client/src/accessibility/shortcuts/registerAll.ts
+++ b/client/src/accessibility/shortcuts/registerAll.ts
@@ -1,9 +1,11 @@
 import { useShortcutStore } from '../../stores/shortcutStore'
 import { handleRoomDescription } from './roomDescription'
 import { handleContextCommands } from './contextCommands'
+import { handleHelpTopic } from './helpTopic'
 
 export function registerAllShortcuts(): void {
   const { register } = useShortcutStore.getState()
   register('room-description', 'Room description', 'Alt+L', handleRoomDescription)
   register('context-commands', 'Context commands', 'Alt+C', handleContextCommands)
+  register('help-topic', 'Read help topic', 'Alt+H', handleHelpTopic)
 }

--- a/client/src/accessibility/shortcuts/roomDescription.ts
+++ b/client/src/accessibility/shortcuts/roomDescription.ts
@@ -1,17 +1,8 @@
 import { useRoomStore } from '../../stores/roomStore'
 import { useAnnounceStore } from '../announceStore'
+import { stripMarkup } from '../../utils/text'
 
-export function stripMarkup(text: string): string {
-  // Remove ANSI escape sequences: \x1b[...m or ESC[...m
-  let result = text.replace(/\x1b\[[0-9;]*m/g, '')
-  // Remove bare bracket-form ANSI sequences that slipped through: [0m, [1;32m, etc.
-  result = result.replace(/\[[0-9;]+m/g, '')
-  // Remove Tapestry color/style tags: {cyan}, {bold}, {reset}, etc.
-  result = result.replace(/\{[a-zA-Z0-9_]+\}/g, '')
-  // Remove any remaining HTML-like tags
-  result = result.replace(/<[^>]+>/g, '')
-  return result
-}
+export { stripMarkup }
 
 export function handleRoomDescription(): void {
   const { current } = useRoomStore.getState()

--- a/client/src/connection/GmcpDispatcher.ts
+++ b/client/src/connection/GmcpDispatcher.ts
@@ -16,6 +16,7 @@ import { useLayoutStore } from '../stores/layoutStore'
 import { useAffectsStore } from '../stores/affectsStore'
 import { useCombatTargetStore } from '../stores/combatTargetStore'
 import { useCombatTargetsStore } from '../stores/combatTargetsStore'
+import { useHelpStore } from '../stores/helpStore'
 import {
   CharVitalsSchema, CharStatusSchema, CharExperienceSchema, CharCommandsSchema,
   CharEffectsSchema, CharCombatTargetSchema, CharCombatTargetsSchema, CharItemsSchema,
@@ -425,10 +426,13 @@ export function initCoreHandlers(): void {
   // --- Response.Help ---
   GmcpDispatcher.register('Response.Help', (data) => {
     const result = ResponseHelpSchema.safeParse(data)
-    if (result.success) {
-      announce(`Help: ${result.data.body}`, 'feedback')
-    } else {
+    if (!result.success) {
       useDebugStore.getState().logConnection('gmcp-parse-error', 'Response.Help')
+      return
+    }
+    // no_match: telnet already sent the "no help found" message; no modal needed
+    if (result.data.status !== 'no_match') {
+      useHelpStore.getState().openHelp(result.data)
     }
   })
 }

--- a/client/src/panels/HelpModal.test.tsx
+++ b/client/src/panels/HelpModal.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HelpModal } from './HelpModal'
+import { useHelpStore } from '../stores/helpStore'
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }))
+vi.mock('../connection/WebSocketClient', () => ({
+    WebSocketClient: { send: mockSend },
+}))
+
+// jsdom doesn't implement showModal/close natively
+beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn()
+    HTMLDialogElement.prototype.close = vi.fn()
+    mockSend.mockClear()
+    useHelpStore.setState({ isOpen: false, response: null })
+})
+
+describe('HelpModal', () => {
+    it('renders nothing visible when closed', () => {
+        render(<HelpModal />)
+        // dialog element exists but showModal was not called and no content is shown
+        expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
+        expect(screen.queryByRole('heading')).toBeNull()
+    })
+
+    it('renders topic title when opened with ok response', () => {
+        useHelpStore.setState({
+            isOpen: true,
+            response: {
+                status: 'ok',
+                topic: { id: 'combat', title: 'Combat', category: 'combat', brief: 'Fight stuff.', body: 'Body here.', syntax: [], seeAlso: [] }
+            }
+        })
+        render(<HelpModal />)
+        expect(screen.getByText('Combat')).toBeTruthy()
+        expect(screen.getByText('Fight stuff.')).toBeTruthy()
+    })
+
+    it('renders disambiguation list when opened with multiple response', () => {
+        useHelpStore.setState({
+            isOpen: true,
+            response: {
+                status: 'multiple',
+                term: 'fight',
+                matches: [
+                    { id: 'combat-basics', title: 'Combat Basics', brief: 'Basic combat.' },
+                    { id: 'combat-advanced', title: 'Advanced Combat', brief: 'Advanced.' }
+                ]
+            }
+        })
+        render(<HelpModal />)
+        expect(screen.getByText('combat-basics')).toBeTruthy()
+        expect(screen.getByText('combat-advanced')).toBeTruthy()
+    })
+
+    it('calls closeHelp when X button is clicked', () => {
+        useHelpStore.setState({
+            isOpen: true,
+            response: { status: 'ok', topic: { id: 'x', title: 'X', category: 'g', brief: 'b', body: 'b', syntax: [], seeAlso: [] } }
+        })
+        render(<HelpModal />)
+        fireEvent.click(screen.getByLabelText('Close help'))
+        expect(useHelpStore.getState().isOpen).toBe(false)
+    })
+})

--- a/client/src/panels/HelpModal.tsx
+++ b/client/src/panels/HelpModal.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef } from 'react'
+import { useHelpStore, type HelpTopicData, type HelpTopicSummary } from '../stores/helpStore'
+import { parseColorTags } from '../utils/text'
+import { WebSocketClient } from '../connection/WebSocketClient'
+
+export function HelpModal() {
+    const { isOpen, response, closeHelp } = useHelpStore()
+    const dialogRef = useRef<HTMLDialogElement>(null)
+    const previousFocusRef = useRef<Element | null>(null)
+
+    useEffect(() => {
+        const dialog = dialogRef.current
+        if (!dialog) { return }
+        if (isOpen) {
+            previousFocusRef.current = document.activeElement
+            dialog.showModal()
+        } else {
+            dialog.close()
+            if (previousFocusRef.current instanceof HTMLElement) {
+                previousFocusRef.current.focus()
+            }
+        }
+    }, [isOpen])
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && isOpen) { closeHelp() }
+        }
+        document.addEventListener('keydown', handler)
+        return () => { document.removeEventListener('keydown', handler) }
+    }, [isOpen, closeHelp])
+
+    return (
+        <dialog
+            ref={dialogRef}
+            className="fixed z-50 m-auto max-w-2xl w-full max-h-[80vh] rounded-lg bg-gray-900 text-gray-100 shadow-2xl p-0 backdrop:bg-black/60 border border-gray-700"
+            onClick={(e) => { if (e.target === dialogRef.current) { closeHelp() } }}
+        >
+            {response && (
+                <div className="flex flex-col max-h-[80vh]">
+                    <header className="flex items-center justify-between px-4 py-3 border-b border-gray-700 shrink-0">
+                        <h2 className="text-lg font-semibold">
+                            {response.status === 'ok'
+                                ? response.topic.title
+                                : `Help: "${(response as { term?: string }).term ?? ''}"`}
+                        </h2>
+                        <button
+                            onClick={closeHelp}
+                            className="text-gray-400 hover:text-gray-100 text-xl leading-none ml-4"
+                            aria-label="Close help"
+                        >
+                            &times;
+                        </button>
+                    </header>
+                    <div className="overflow-y-auto px-4 py-4 flex-1">
+                        {response.status === 'ok' && <HelpTopicContent topic={response.topic} />}
+                        {response.status === 'multiple' && (
+                            <HelpDisambiguation term={response.term} matches={response.matches} />
+                        )}
+                        {response.status === 'no_match' && (
+                            <p className="text-gray-400 text-sm">No help topic found for "{response.term}".</p>
+                        )}
+                    </div>
+                </div>
+            )}
+        </dialog>
+    )
+}
+
+function HelpTopicContent({ topic }: { topic: HelpTopicData }) {
+    function sendCommand(cmd: string) {
+        WebSocketClient.send(cmd)
+    }
+
+    return (
+        <div className="space-y-4">
+            <p className="text-gray-400 italic">{topic.brief}</p>
+
+            {topic.syntax.length > 0 && (
+                <div>
+                    <p className="text-sm font-semibold text-gray-300 mb-1">Syntax:</p>
+                    <div className="bg-gray-800 rounded px-3 py-2 font-mono text-sm space-y-1">
+                        {topic.syntax.map((s, i) => <div key={i}>{s}</div>)}
+                    </div>
+                </div>
+            )}
+
+            <div className="text-sm leading-relaxed whitespace-pre-wrap">
+                <ColorTaggedText text={topic.body} />
+            </div>
+
+            {topic.seeAlso.length > 0 && (
+                <div className="pt-2 border-t border-gray-700 text-sm">
+                    <span className="text-gray-400">See also: </span>
+                    {topic.seeAlso.map((id, i) => (
+                        <span key={id}>
+                            <button
+                                className="text-blue-400 hover:underline"
+                                onClick={() => { sendCommand(`help ${id}`) }}
+                            >
+                                {id}
+                            </button>
+                            {i < topic.seeAlso.length - 1 && <span className="text-gray-500">, </span>}
+                        </span>
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}
+
+function HelpDisambiguation({ term, matches }: { term: string; matches: HelpTopicSummary[] }) {
+    function sendCommand(cmd: string) {
+        WebSocketClient.send(cmd)
+    }
+
+    return (
+        <div className="space-y-2">
+            <p className="text-gray-400 text-sm">Multiple topics match "{term}":</p>
+            <ul className="space-y-1">
+                {matches.map((m) => (
+                    <li key={m.id}>
+                        <button
+                            className="text-left w-full hover:bg-gray-800 rounded px-2 py-1.5 flex gap-3"
+                            onClick={() => { sendCommand(`help ${m.id}`) }}
+                        >
+                            <span className="text-blue-400 font-mono shrink-0">{m.id}</span>
+                            <span className="text-gray-300">{m.title}</span>
+                        </button>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+}
+
+function ColorTaggedText({ text }: { text: string }) {
+    const parts = parseColorTags(text)
+    return (
+        <>
+            {parts.map((part, i) =>
+                part.className
+                    ? <span key={i} className={part.className}>{part.text}</span>
+                    : <span key={i}>{part.text}</span>
+            )}
+        </>
+    )
+}

--- a/client/src/panels/HelpModal.tsx
+++ b/client/src/panels/HelpModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useHelpStore, type HelpTopicData, type HelpTopicSummary } from '../stores/helpStore'
-import { parseColorTags } from '../utils/text'
+import { parseColorTags, stripMarkup } from '../utils/text'
+import { useAnnounceStore } from '../accessibility/announceStore'
 import { WebSocketClient } from '../connection/WebSocketClient'
 
 export function HelpModal() {
@@ -21,6 +22,15 @@ export function HelpModal() {
             }
         }
     }, [isOpen])
+
+    useEffect(() => {
+        if (!isOpen || !response || response.status !== 'ok') { return }
+        const topic = response.topic
+        const parts: string[] = [topic.brief]
+        if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
+        if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
+        useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'polite')
+    }, [isOpen, response])
 
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {

--- a/client/src/panels/HelpModal.tsx
+++ b/client/src/panels/HelpModal.tsx
@@ -42,7 +42,9 @@ export function HelpModal() {
                         <h2 className="text-lg font-semibold">
                             {response.status === 'ok'
                                 ? response.topic.title
-                                : `Help: "${(response as { term?: string }).term ?? ''}"`}
+                                : response.status === 'multiple' || response.status === 'no_match'
+                                    ? `Help: "${response.term}"`
+                                    : ''}
                         </h2>
                         <button
                             onClick={closeHelp}
@@ -67,11 +69,11 @@ export function HelpModal() {
     )
 }
 
-function HelpTopicContent({ topic }: { topic: HelpTopicData }) {
-    function sendCommand(cmd: string) {
-        WebSocketClient.send(cmd)
-    }
+function sendCommand(cmd: string) {
+    WebSocketClient.send(cmd)
+}
 
+function HelpTopicContent({ topic }: { topic: HelpTopicData }) {
     return (
         <div className="space-y-4">
             <p className="text-gray-400 italic">{topic.brief}</p>
@@ -110,10 +112,6 @@ function HelpTopicContent({ topic }: { topic: HelpTopicData }) {
 }
 
 function HelpDisambiguation({ term, matches }: { term: string; matches: HelpTopicSummary[] }) {
-    function sendCommand(cmd: string) {
-        WebSocketClient.send(cmd)
-    }
-
     return (
         <div className="space-y-2">
             <p className="text-gray-400 text-sm">Multiple topics match "{term}":</p>

--- a/client/src/stores/helpStore.test.ts
+++ b/client/src/stores/helpStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useHelpStore } from './helpStore'
+import type { HelpResponse } from './helpStore'
+
+const okResp: HelpResponse = {
+    status: 'ok',
+    topic: { id: 'test', title: 'Test', category: 'general', brief: 'brief', body: 'body', syntax: [], seeAlso: [] }
+}
+
+describe('helpStore', () => {
+    beforeEach(() => {
+        useHelpStore.setState({ isOpen: false, response: null })
+    })
+
+    it('starts closed with no response', () => {
+        const state = useHelpStore.getState()
+        expect(state.isOpen).toBe(false)
+        expect(state.response).toBeNull()
+    })
+
+    it('openHelp sets isOpen true and stores response', () => {
+        useHelpStore.getState().openHelp(okResp)
+        expect(useHelpStore.getState().isOpen).toBe(true)
+        expect(useHelpStore.getState().response).toEqual(okResp)
+    })
+
+    it('closeHelp sets isOpen false', () => {
+        useHelpStore.getState().openHelp(okResp)
+        useHelpStore.getState().closeHelp()
+        expect(useHelpStore.getState().isOpen).toBe(false)
+    })
+})

--- a/client/src/stores/helpStore.ts
+++ b/client/src/stores/helpStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand'
+
+export interface HelpTopicData {
+    id: string
+    title: string
+    category: string
+    brief: string
+    body: string
+    syntax: string[]
+    seeAlso: string[]
+}
+
+export interface HelpTopicSummary {
+    id: string
+    title: string
+    brief: string
+}
+
+export type HelpResponse =
+    | { status: 'ok'; topic: HelpTopicData }
+    | { status: 'multiple'; term: string; matches: HelpTopicSummary[] }
+    | { status: 'no_match'; term: string }
+
+interface HelpState {
+    isOpen: boolean
+    response: HelpResponse | null
+    openHelp: (response: HelpResponse) => void
+    closeHelp: () => void
+}
+
+export const useHelpStore = create<HelpState>()((set) => ({
+    isOpen: false,
+    response: null,
+    openHelp: (response) => { set({ isOpen: true, response }) },
+    closeHelp: () => { set({ isOpen: false }) },
+}))

--- a/client/src/types/responseGmcp.ts
+++ b/client/src/types/responseGmcp.ts
@@ -157,12 +157,24 @@ export type ResponseLook = z.infer<typeof ResponseLookSchema>
 
 // --- Response.Help ---
 
-export const ResponseHelpSchema = z.object({
-  status: z.enum(['ok', 'error']),
-  topic: z.string(),
-  category: z.string().optional(),
-  body: z.string(),
-  seeAlso: z.array(z.string()).optional(),
+const ResponseHelpTopicSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  category: z.string().default(''),
+  brief: z.string().default(''),
+  body: z.string().default(''),
+  syntax: z.array(z.string()).default([]),
+  seeAlso: z.array(z.string()).default([]),
 })
+
+export const ResponseHelpSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('ok'), topic: ResponseHelpTopicSchema }),
+  z.object({
+    status: z.literal('multiple'),
+    term: z.string(),
+    matches: z.array(z.object({ id: z.string(), title: z.string(), brief: z.string() })),
+  }),
+  z.object({ status: z.literal('no_match'), term: z.string() }),
+])
 
 export type ResponseHelp = z.infer<typeof ResponseHelpSchema>

--- a/client/src/utils/text.test.ts
+++ b/client/src/utils/text.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { stripMarkup, parseColorTags } from './text'
+
+describe('stripMarkup', () => {
+    it('strips ANSI escape sequences', () => {
+        expect(stripMarkup('\x1b[32mgreen\x1b[0m')).toBe('green')
+    })
+
+    it('strips bracket-form ANSI', () => {
+        expect(stripMarkup('[32mtext[0m')).toBe('text')
+    })
+
+    it('strips Tapestry brace color tags', () => {
+        expect(stripMarkup('{cyan}text{reset}')).toBe('text')
+    })
+
+    it('strips semantic angle-bracket tags', () => {
+        expect(stripMarkup('<highlight>text</highlight>')).toBe('text')
+    })
+
+    it('passes plain text through unchanged', () => {
+        expect(stripMarkup('plain text')).toBe('plain text')
+    })
+})
+
+describe('parseColorTags', () => {
+    it('returns single plain segment for plain text', () => {
+        const parts = parseColorTags('hello')
+        expect(parts).toHaveLength(1)
+        expect(parts[0].text).toBe('hello')
+        expect(parts[0].className).toBeUndefined()
+    })
+
+    it('returns tagged segment with className for known tag', () => {
+        const parts = parseColorTags('<highlight>bright</highlight>')
+        expect(parts).toHaveLength(1)
+        expect(parts[0].text).toBe('bright')
+        expect(parts[0].className).toContain('text-yellow')
+    })
+
+    it('handles mixed tagged and plain text', () => {
+        const parts = parseColorTags('before <highlight>mid</highlight> after')
+        expect(parts).toHaveLength(3)
+        expect(parts[0].text).toBe('before ')
+        expect(parts[1].className).toBeTruthy()
+        expect(parts[2].text).toBe(' after')
+    })
+})

--- a/client/src/utils/text.ts
+++ b/client/src/utils/text.ts
@@ -1,0 +1,41 @@
+export function stripMarkup(text: string): string {
+    let result = text.replace(/\x1b\[[0-9;]*m/g, '')
+    result = result.replace(/\[[0-9;]+m/g, '')
+    result = result.replace(/\{[a-zA-Z0-9_]+\}/g, '')
+    result = result.replace(/<[^>]+>/g, '')
+    return result
+}
+
+const COLOR_TAG_CLASSES: Record<string, string> = {
+    highlight: 'text-yellow-300 font-semibold',
+    danger: 'text-red-400',
+    subtle: 'text-gray-400 italic',
+    item: 'text-blue-300',
+    'item.common': 'text-gray-300',
+    'item.uncommon': 'text-green-300',
+    'item.rare': 'text-blue-300',
+    'item.epic': 'text-purple-300',
+    npc: 'text-green-400',
+    player: 'text-cyan-300',
+}
+
+export interface ColorSegment {
+    text: string
+    className?: string
+}
+
+export function parseColorTags(text: string): ColorSegment[] {
+    const parts: ColorSegment[] = []
+    const re = /<([a-zA-Z0-9_.]+)>([\s\S]*?)<\/\1>|([^<]+)/g
+    let match: RegExpExecArray | null
+
+    while ((match = re.exec(text)) !== null) {
+        if (match[3] !== undefined) {
+            parts.push({ text: match[3] })
+        } else {
+            parts.push({ text: match[2], className: COLOR_TAG_CLASSES[match[1]] })
+        }
+    }
+
+    return parts
+}

--- a/packs/example-pack/help/classes.yaml
+++ b/packs/example-pack/help/classes.yaml
@@ -1,0 +1,9 @@
+id: "classes"
+title: "Choosing a Class"
+category: "creation"
+keywords: [class, classes, character creation, spells, skills]
+brief: "Each class has unique skills and spells."
+body: |
+  Your class determines your starting skill and spell tree
+
+  Type help [class name] for details on a specific class.

--- a/packs/example-pack/help/combat-basics.yaml
+++ b/packs/example-pack/help/combat-basics.yaml
@@ -1,0 +1,17 @@
+id: "combat-basics"
+title: "Combat Basics"
+category: "combat"
+role: "player"
+keywords: [fighting, attack, kill, hit]
+brief: "Use kill [target] to start combat. Flee to escape."
+syntax:
+  - "kill [target]"
+  - "flee"
+body: |
+  Combat begins when you attack a target with the kill command.
+  Once engaged, you will automatically exchange blows each round.
+
+  Before engaging, use consider to gauge how dangerous a target
+  is relative to your level. If things go badly, flee will
+  attempt to escape combat.
+see_also: [combat]

--- a/packs/example-pack/help/combat.yaml
+++ b/packs/example-pack/help/combat.yaml
@@ -1,0 +1,12 @@
+id: "combat"
+title: "Combat"
+category: "combat"
+role: "player"
+brief: "How fighting works in the world."
+body: |
+  Combat in Tapestry is round-based. Attack a target to engage,
+  then exchange blows each round until one side falls or flees.
+
+  See the related topics below for details on specific aspects
+  of the combat system.
+see_also: [combat-basics]

--- a/packs/example-pack/help/races.yaml
+++ b/packs/example-pack/help/races.yaml
@@ -1,6 +1,6 @@
 id: "races"
 title: "Choosing a Race"
-category: "chargen"
+category: "creation"
 keywords: [race, races, character creation, species]
 brief: "Each race has unique stats and abilities."
 body: |

--- a/packs/example-pack/help/races.yaml
+++ b/packs/example-pack/help/races.yaml
@@ -1,0 +1,10 @@
+id: "races"
+title: "Choosing a Race"
+category: "chargen"
+keywords: [race, races, character creation, species]
+brief: "Each race has unique stats and abilities."
+body: |
+  Your race determines your starting attributes and grants
+  access to racial abilities as you level.
+
+  Type help [race name] for details on a specific race.

--- a/packs/example-pack/pack.yaml
+++ b/packs/example-pack/pack.yaml
@@ -16,3 +16,4 @@ content:
   items: "areas/**/items/*.yaml"
   scripts: "scripts/**/*.js"
   mobs: "areas/**/mobs/*.yaml"
+  help: "help/**/*.yaml"

--- a/packs/example-pack/scripts/flows/character_creation.js
+++ b/packs/example-pack/scripts/flows/character_creation.js
@@ -39,6 +39,7 @@ tapestry.flows.register({
         {
             id: "race",
             type: "choice",
+            help_hint: "races",
             prompt: "Choose your race:",
             options: function() {
                 return tapestry.races.getAll().map(function(r) {
@@ -57,6 +58,7 @@ tapestry.flows.register({
         {
             id: "gender",
             type: "choice",
+            help_hint: "gender",
             prompt: "Choose your gender:",
             options: CORE_GENDER_OPTIONS,
             on_select: function(entity, option) {
@@ -66,6 +68,7 @@ tapestry.flows.register({
         {
             id: "class",
             type: "choice",
+            help_hint: "classes",
             prompt: "Choose your class:",
             options: function(entity) {
                 var raceId = entity.getProperty("race");

--- a/packs/tapestry-core/pack.yaml
+++ b/packs/tapestry-core/pack.yaml
@@ -18,3 +18,4 @@ content:
   equipment_slots: "equipment_slots.yaml"
   scripts: "scripts/**/*.js"
   strings: "strings/**/*.yaml"
+  help: "help/**/*.yaml"

--- a/packs/tapestry-core/scripts/commands/help.js
+++ b/packs/tapestry-core/scripts/commands/help.js
@@ -10,7 +10,7 @@ tapestry.commands.register({
         var term = args ? String(args).trim() : '';
 
         if (!term) {
-            var cats = tapestry.help.categories(helpId);
+            var cats = helpId ? tapestry.help.categories(helpId) : tapestry.help.categories();
 
             if (cats.length === 0) {
                 player.send('No help topics available.\r\n');
@@ -20,7 +20,7 @@ tapestry.commands.register({
             var lines = ['Help Topics:\r\n'];
             for (var i = 0; i < cats.length; i++) {
                 var cat = String(cats[i]);
-                var topics = tapestry.help.list(helpId, cat);
+                var topics = helpId ? tapestry.help.list(helpId, cat) : tapestry.help.list(cat);
                 lines.push('  ' + cat + ' (' + topics.length + (topics.length === 1 ? ' topic' : ' topics') + ')\r\n');
             }
             lines.push('\r\nType help [topic] for details.\r\n');
@@ -28,7 +28,7 @@ tapestry.commands.register({
             return;
         }
 
-        var result = tapestry.help.query(helpId, term);
+        var result = helpId ? tapestry.help.query(helpId, term) : tapestry.help.query(term);
 
         if (result.status === 'ok') {
             player.send(tapestry.ui.help(result));

--- a/packs/tapestry-core/scripts/commands/help.js
+++ b/packs/tapestry-core/scripts/commands/help.js
@@ -1,44 +1,53 @@
 tapestry.commands.register({
     name: 'help',
     aliases: ['?'],
-    description: 'Show help for a command or topic.',
-    priority: 0,
+    description: 'Browse or search help topics.',
+    priority: 100,
     handler: function(player, args) {
-        var topic = args.length > 0 ? args.join(' ') : 'commands';
-
-        var helpBody = [
-            'Movement:  north(n) south(s) east(e) west(w) up(u) down(d)',
-            'Looking:   look(l) exits examine(ex)',
-            'Items:     get(take) drop give put',
-            'Equipment: wear wield remove equipment(eq)',
-            "Talking:   say(') yell emote(:)",
-            'Info:      who help(?) score inventory(i) motd',
-            'Other:     recall quit(qq)'
-        ].join('\n');
-
-        tapestry.gmcp.send(player.entityId, 'Response.Help', {
-            status: 'ok',
-            topic: topic,
-            body: helpBody,
-            seeAlso: []
-        });
-
         tapestry.respond.suppress(player.entityId);
 
-        var output = tapestry.ui.panel({
-            sections: [{
-                rows: [
-                    { type: 'title', left: 'Tapestry Commands' },
-                    { type: 'text', content: "  Movement:  north(n) south(s) east(e) west(w) up(u) down(d)" },
-                    { type: 'text', content: '  Looking:   look(l) exits examine(ex)' },
-                    { type: 'text', content: '  Items:     get(take) drop give put' },
-                    { type: 'text', content: '  Equipment: wear wield remove equipment(eq)' },
-                    { type: 'text', content: "  Talking:   say(') yell emote(:)" },
-                    { type: 'text', content: '  Info:      who help(?) score inventory(i) motd' },
-                    { type: 'text', content: '  Other:     recall quit(qq)' }
-                ]
-            }]
-        });
-        player.send('\r\n' + output + '\r\n');
+        var term = (args || '').trim();
+
+        if (!term) {
+            var cats = tapestry.help.categories(player.entityId);
+
+            if (cats.length === 0) {
+                player.send('No help topics available.\r\n');
+                return;
+            }
+
+            var lines = ['Help Topics:\r\n'];
+            for (var i = 0; i < cats.length; i++) {
+                var cat = cats[i];
+                var topics = tapestry.help.list(player.entityId, cat);
+                lines.push('  ' + cat + ' (' + topics.length + (topics.length === 1 ? ' topic' : ' topics') + ')\r\n');
+            }
+            lines.push('\r\nType help [topic] for details.\r\n');
+            player.send(lines.join(''));
+            return;
+        }
+
+        var result = tapestry.help.query(player.entityId, term);
+
+        if (result.status === 'ok') {
+            player.send(tapestry.ui.help(result));
+            tapestry.gmcp.send(player.entityId, 'Response.Help', {
+                status: 'ok',
+                topic: result.topic
+            });
+        } else if (result.status === 'multiple') {
+            player.send(tapestry.ui.help(result));
+            tapestry.gmcp.send(player.entityId, 'Response.Help', {
+                status: 'multiple',
+                term: result.term,
+                matches: result.matches
+            });
+        } else {
+            player.send(tapestry.ui.help(result));
+            tapestry.gmcp.send(player.entityId, 'Response.Help', {
+                status: 'no_match',
+                term: result.term
+            });
+        }
     }
 });

--- a/packs/tapestry-core/scripts/commands/help.js
+++ b/packs/tapestry-core/scripts/commands/help.js
@@ -6,10 +6,11 @@ tapestry.commands.register({
     handler: function(player, args) {
         tapestry.respond.suppress(player.entityId);
 
+        var helpId = player.isChargen ? null : player.entityId;
         var term = args ? String(args).trim() : '';
 
         if (!term) {
-            var cats = tapestry.help.categories(player.entityId);
+            var cats = tapestry.help.categories(helpId);
 
             if (cats.length === 0) {
                 player.send('No help topics available.\r\n');
@@ -18,8 +19,8 @@ tapestry.commands.register({
 
             var lines = ['Help Topics:\r\n'];
             for (var i = 0; i < cats.length; i++) {
-                var cat = cats[i];
-                var topics = tapestry.help.list(player.entityId, cat);
+                var cat = String(cats[i]);
+                var topics = tapestry.help.list(helpId, cat);
                 lines.push('  ' + cat + ' (' + topics.length + (topics.length === 1 ? ' topic' : ' topics') + ')\r\n');
             }
             lines.push('\r\nType help [topic] for details.\r\n');
@@ -27,7 +28,7 @@ tapestry.commands.register({
             return;
         }
 
-        var result = tapestry.help.query(player.entityId, term);
+        var result = tapestry.help.query(helpId, term);
 
         if (result.status === 'ok') {
             player.send(tapestry.ui.help(result));

--- a/packs/tapestry-core/scripts/commands/help.js
+++ b/packs/tapestry-core/scripts/commands/help.js
@@ -6,7 +6,7 @@ tapestry.commands.register({
     handler: function(player, args) {
         tapestry.respond.suppress(player.entityId);
 
-        var term = (args || '').trim();
+        var term = args ? String(args).trim() : '';
 
         if (!term) {
             var cats = tapestry.help.categories(player.entityId);

--- a/src/Tapestry.Engine/Flow/FlowEngine.cs
+++ b/src/Tapestry.Engine/Flow/FlowEngine.cs
@@ -60,6 +60,7 @@ public class FlowEngine
         var instance = new FlowInstance(definition, session.PlayerEntity, _panelRenderer);
         instance.OnCompleted = () => Complete(session);
         instance.GmcpSend = GmcpSend;
+        instance.CommandFallback = input => session.EnqueueInput(input);
         session.CurrentFlow = instance;
         _playerCreator.TrackEntity(session.PlayerEntity);
         instance.Start(session);

--- a/src/Tapestry.Engine/Flow/FlowInstance.cs
+++ b/src/Tapestry.Engine/Flow/FlowInstance.cs
@@ -14,6 +14,7 @@ public class FlowInstance
 
     public Action? OnCompleted { get; set; }
     public Action<string, string, object>? GmcpSend { get; set; }
+    public Action<string>? CommandFallback { get; set; }
     public FlowDefinition Definition => _definition;
     public Entity Entity => _entity;
     public int CurrentStepIndex => _currentStepIndex;
@@ -39,6 +40,25 @@ public class FlowInstance
             return;
         }
 
+        var trimmed = input.Trim();
+        var lower = trimmed.ToLowerInvariant();
+
+        if (lower == "?" || lower == "help")
+        {
+            CommandFallback?.Invoke("help");
+            return;
+        }
+        if (trimmed.StartsWith("? "))
+        {
+            CommandFallback?.Invoke("help " + trimmed[2..].Trim());
+            return;
+        }
+        if (lower.StartsWith("help "))
+        {
+            CommandFallback?.Invoke(trimmed);
+            return;
+        }
+
         var step = _definition.Steps[_currentStepIndex];
 
         switch (step)
@@ -59,67 +79,6 @@ public class FlowInstance
     {
         var trimmed = input.Trim();
         var lower = trimmed.ToLowerInvariant();
-
-        if (lower == "?" || lower == "help")
-        {
-            _session!.SendLine("Type ? [option] or ? [number] to learn more about a choice.");
-            if (_definition.WizardSteps == null || !_session!.Connection.SupportsAnsi)
-            {
-                RenderCurrentStep();
-            }
-            return;
-        }
-
-        string? helpTarget = null;
-        if (trimmed.StartsWith("? "))
-        {
-            helpTarget = trimmed[2..].Trim();
-        }
-        else if (lower.StartsWith("help "))
-        {
-            helpTarget = trimmed[5..].Trim();
-        }
-
-        if (helpTarget != null)
-        {
-            var opts = step.Options(_entity);
-            ChoiceOption? match;
-
-            if (int.TryParse(helpTarget, out var helpNum) && helpNum >= 1 && helpNum <= opts.Count)
-            {
-                match = opts[helpNum - 1];
-            }
-            else
-            {
-                var targetLower = helpTarget.ToLowerInvariant();
-                match = opts.FirstOrDefault(o => o.Label.ToLowerInvariant().StartsWith(targetLower));
-            }
-
-            if (match == null)
-            {
-                var unknownText = $"Unknown option: {helpTarget}";
-                _session!.SendLine(unknownText);
-                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Help", new { text = unknownText });
-            }
-            else if (match.Description != null)
-            {
-                var descText = match.Description(_entity);
-                _session!.SendLine(descText);
-                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Help", new { text = descText });
-            }
-            else
-            {
-                var noInfoText = $"No additional information available for {match.Label}.";
-                _session!.SendLine(noInfoText);
-                GmcpSend?.Invoke(_session!.Connection.Id, "Flow.Help", new { text = noInfoText });
-            }
-            if (_definition.WizardSteps == null || !_session!.Connection.SupportsAnsi)
-            {
-                RenderCurrentStep();
-            }
-            return;
-        }
-
         var options = step.Options(_entity);
         ChoiceOption? chosen = null;
 
@@ -235,7 +194,8 @@ public class FlowInstance
                     {
                         _session!.SendLine($"  {i + 1}. {options[i].Label}");
                     }
-                    _session!.SendLine("  ? [option] or ? [number] for details");
+                    var hint = choice.HelpHint != null ? $"help {choice.HelpHint}" : "help [topic]";
+                    _session!.SendLine($"  Type {hint} for details");
                 }
                 var choiceOptions = choice.Options(_entity);
                 var choicePayload = choiceOptions.Select(o => o.TagLine != null
@@ -366,7 +326,7 @@ public class FlowInstance
                 SeparatorAbove = RuleStyle.Major,
                 Rows = new Row[]
                 {
-                    new FooterRow { Content = "? [option] or ? [number] for details" }
+                    new FooterRow { Content = step.HelpHint != null ? $"Type help {step.HelpHint} for details" : "Type help [topic] for details" }
                 }
             });
         }

--- a/src/Tapestry.Engine/Flow/FlowStepDefinition.cs
+++ b/src/Tapestry.Engine/Flow/FlowStepDefinition.cs
@@ -18,6 +18,7 @@ public class ChoiceStep : FlowStepDefinition
     public required Func<Entity, string> Prompt { get; init; }
     public required Func<Entity, IReadOnlyList<ChoiceOption>> Options { get; init; }
     public required Action<Entity, ChoiceOption> OnSelect { get; init; }
+    public string? HelpHint { get; init; }
 }
 
 public class TextStep : FlowStepDefinition

--- a/src/Tapestry.Engine/GameLoop.cs
+++ b/src/Tapestry.Engine/GameLoop.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Tapestry.Engine.Flow;
 using Tapestry.Engine.Stats;
 using Tapestry.Engine.Rest;
 using Tapestry.Engine.Sustenance;
@@ -179,7 +180,8 @@ public class GameLoop
                     PlayerEntityId = session.PlayerEntity.Id,
                     RawInput = actualInput,
                     Command = parts[0],
-                    Args = parts.Length > 1 ? parts[1..] : []
+                    Args = parts.Length > 1 ? parts[1..] : [],
+                    IsChargen = session.Phase == SessionPhase.Creating
                 };
 
                 var handlerSw = Stopwatch.StartNew();

--- a/src/Tapestry.Engine/Help/HelpService.cs
+++ b/src/Tapestry.Engine/Help/HelpService.cs
@@ -45,6 +45,7 @@ public class HelpService
             .IgnoreUnmatchedProperties()
             .Build();
 
+        // helpGlob serves as an enabled-guard; GetFiles doesn't support ** patterns so all .yaml files are loaded
         foreach (var file in Directory.GetFiles(helpDir, "*.yaml", SearchOption.AllDirectories).OrderBy(f => f))
         {
             try

--- a/src/Tapestry.Engine/Help/HelpService.cs
+++ b/src/Tapestry.Engine/Help/HelpService.cs
@@ -1,0 +1,167 @@
+using Microsoft.Extensions.Logging;
+using Tapestry.Shared.Help;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Tapestry.Engine.Help;
+
+public class HelpQueryResult
+{
+    public string Status { get; set; } = "";
+    public string? Term { get; set; }
+    public HelpTopic? Topic { get; set; }
+    public List<HelpTopicSummary>? Matches { get; set; }
+}
+
+public class HelpService
+{
+    private readonly ILogger<HelpService>? _logger;
+
+    private readonly Dictionary<string, (HelpTopic Topic, int LoadOrder)> _byId
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly Dictionary<string, (HelpTopic Topic, int LoadOrder)> _byTitle
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly Dictionary<string, List<HelpTopic>> _byCategory
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly string[] RoleHierarchy = ["player", "builder", "admin"];
+
+    public HelpService(ILogger<HelpService>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public void LoadPack(string packName, string packRoot, string helpGlob, int loadOrder)
+    {
+        if (string.IsNullOrWhiteSpace(helpGlob)) { return; }
+
+        var helpDir = Path.Combine(packRoot, "help");
+        if (!Directory.Exists(helpDir)) { return; }
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        foreach (var file in Directory.GetFiles(helpDir, "*.yaml", SearchOption.AllDirectories).OrderBy(f => f))
+        {
+            try
+            {
+                var topic = deserializer.Deserialize<HelpTopic>(File.ReadAllText(file));
+                if (string.IsNullOrWhiteSpace(topic.Id) || string.IsNullOrWhiteSpace(topic.Title))
+                {
+                    _logger?.LogWarning("Help topic in {File} missing required fields id or title - skipping", file);
+                    continue;
+                }
+                topic.PackName = packName;
+                AddTopic(topic, loadOrder);
+                _logger?.LogDebug("  Help topic: {Id}", topic.NamespacedId);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to load help topic from {File}", file);
+            }
+        }
+    }
+
+    public void AddTopic(HelpTopic topic, int loadOrder = 0)
+    {
+        UpsertIfHigher(_byId, topic.Id, topic, loadOrder);
+        UpsertIfHigher(_byId, topic.NamespacedId, topic, loadOrder);
+        UpsertIfHigher(_byTitle, topic.Title, topic, loadOrder);
+
+        if (!_byCategory.ContainsKey(topic.Category)) { _byCategory[topic.Category] = new(); }
+
+        _byCategory[topic.Category].RemoveAll(t => t.Id == topic.Id && t.PackName == topic.PackName);
+        _byCategory[topic.Category].Add(topic);
+    }
+
+    public HelpQueryResult Query(string? entityId, string term)
+    {
+        var tier = PlayerTier(entityId);
+
+        if (_byId.TryGetValue(term, out var idHit) && IsVisible(idHit.Topic, tier))
+        {
+            return new() { Status = "ok", Topic = idHit.Topic };
+        }
+
+        if (_byTitle.TryGetValue(term, out var titleHit) && IsVisible(titleHit.Topic, tier))
+        {
+            return new() { Status = "ok", Topic = titleHit.Topic };
+        }
+
+        var fuzzy = _byId.Values
+            .Select(x => x.Topic)
+            .Where(t => IsVisible(t, tier) && MatchesFuzzy(t, term))
+            .DistinctBy(t => t.NamespacedId)
+            .ToList();
+
+        if (fuzzy.Count == 1) { return new() { Status = "ok", Topic = fuzzy[0] }; }
+
+        if (fuzzy.Count > 1)
+        {
+            return new()
+            {
+                Status = "multiple",
+                Term = term,
+                Matches = fuzzy.Select(t => new HelpTopicSummary { Id = t.Id, Title = t.Title, Brief = t.Brief }).ToList()
+            };
+        }
+
+        return new() { Status = "no_match", Term = term };
+    }
+
+    public List<HelpTopicSummary> List(string? entityId, string category)
+    {
+        var tier = PlayerTier(entityId);
+        if (!_byCategory.TryGetValue(category, out var topics)) { return new(); }
+
+        return topics
+            .Where(t => IsVisible(t, tier))
+            .Select(t => new HelpTopicSummary { Id = t.Id, Title = t.Title, Brief = t.Brief })
+            .ToList();
+    }
+
+    public List<string> Categories(string? entityId)
+    {
+        var tier = PlayerTier(entityId);
+        return _byCategory
+            .Where(kv => kv.Value.Any(t => IsVisible(t, tier)))
+            .Select(kv => kv.Key)
+            .OrderBy(c => c)
+            .ToList();
+    }
+
+    private static void UpsertIfHigher(
+        Dictionary<string, (HelpTopic, int)> dict,
+        string key,
+        HelpTopic topic,
+        int loadOrder)
+    {
+        if (!dict.TryGetValue(key, out var existing) || loadOrder >= existing.Item2)
+        {
+            dict[key] = (topic, loadOrder);
+        }
+    }
+
+    private static bool MatchesFuzzy(HelpTopic t, string term) =>
+        t.Title.Contains(term, StringComparison.OrdinalIgnoreCase)
+        || t.Keywords.Any(k => k.Contains(term, StringComparison.OrdinalIgnoreCase));
+
+    private static int RoleTier(string? role)
+    {
+        if (string.IsNullOrWhiteSpace(role)) { return -1; }
+        var idx = Array.IndexOf(RoleHierarchy, role.ToLowerInvariant());
+        return idx;
+    }
+
+    private static bool IsVisible(HelpTopic t, int playerTier) =>
+        RoleTier(t.Role) <= playerTier;
+
+    // -1 = no player (chargen) -- only role-less visible
+    // any GUID = player tier for now
+    private static int PlayerTier(string? entityId) =>
+        string.IsNullOrWhiteSpace(entityId) ? -1 : RoleTier("player");
+}

--- a/src/Tapestry.Engine/ServiceCollectionExtensions.cs
+++ b/src/Tapestry.Engine/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using Tapestry.Engine.Sustenance;
 using Tapestry.Engine.Consumables;
 using Tapestry.Engine.Rest;
 using Tapestry.Engine.Ui;
+using Tapestry.Engine.Help;
 using Tapestry.Data;
 
 namespace Tapestry.Engine;
@@ -156,6 +157,9 @@ public static class ServiceCollectionExtensions
                     new CheckWimpyPhase()
                 });
         });
+
+        // Help
+        services.AddSingleton<HelpService>();
 
         // Color / Rendering
         services.AddSingleton<ThemeRegistry>();

--- a/src/Tapestry.Engine/Ui/HelpRenderer.cs
+++ b/src/Tapestry.Engine/Ui/HelpRenderer.cs
@@ -50,7 +50,7 @@ public static class HelpRenderer
         sb.AppendLine("  Multiple matches found:");
         sb.AppendLine();
 
-        var pad = matches.Max(m => m.Id.Length) + 4;
+        var pad = matches.Count > 0 ? matches.Max(m => m.Id.Length) + 4 : 4;
         foreach (var m in matches)
         {
             sb.AppendLine($"    {m.Id.PadRight(pad)}{m.Title}");

--- a/src/Tapestry.Engine/Ui/HelpRenderer.cs
+++ b/src/Tapestry.Engine/Ui/HelpRenderer.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using Tapestry.Shared.Help;
+
+namespace Tapestry.Engine.Ui;
+
+public static class HelpRenderer
+{
+    private const char Rule = '━'; // ━
+
+    public static string RenderTopic(HelpTopic topic, int width = 78)
+    {
+        var sb = new StringBuilder();
+        var label = $" {topic.Title} ";
+        var trailing = new string(Rule, Math.Max(0, width - 4 - label.Length));
+        sb.AppendLine($"  {new string(Rule, 3)}{label}{trailing}");
+        sb.AppendLine($"  <subtle>{topic.Brief}</subtle>");
+
+        if (topic.Syntax.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("  Syntax:");
+            foreach (var line in topic.Syntax)
+            {
+                sb.AppendLine($"    {line}");
+            }
+        }
+
+        sb.AppendLine();
+        foreach (var line in topic.Body.Split('\n'))
+        {
+            sb.AppendLine($"  {line.TrimEnd()}");
+        }
+
+        if (topic.SeeAlso.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"  See also: {string.Join(", ", topic.SeeAlso)}");
+        }
+
+        sb.AppendLine($"  {new string(Rule, width - 2)}");
+        return sb.ToString();
+    }
+
+    public static string RenderDisambiguation(string term, List<HelpTopicSummary> matches, int width = 78)
+    {
+        var sb = new StringBuilder();
+        var label = $" Help: \"{term}\" ";
+        var trailing = new string(Rule, Math.Max(0, width - 4 - label.Length));
+        sb.AppendLine($"  {new string(Rule, 3)}{label}{trailing}");
+        sb.AppendLine("  Multiple matches found:");
+        sb.AppendLine();
+
+        var pad = matches.Max(m => m.Id.Length) + 4;
+        foreach (var m in matches)
+        {
+            sb.AppendLine($"    {m.Id.PadRight(pad)}{m.Title}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("  Type help [topic] for details.");
+        sb.AppendLine($"  {new string(Rule, width - 2)}");
+        return sb.ToString();
+    }
+
+    public static string RenderNoMatch(string term)
+    {
+        return $"No help found for '{term}'.\r\n";
+    }
+}

--- a/src/Tapestry.Engine/Ui/HelpRenderer.cs
+++ b/src/Tapestry.Engine/Ui/HelpRenderer.cs
@@ -5,7 +5,7 @@ namespace Tapestry.Engine.Ui;
 
 public static class HelpRenderer
 {
-    private const char Rule = '━'; // ━
+    private const char Rule = '=';
 
     public static string RenderTopic(HelpTopic topic, int width = 78)
     {

--- a/src/Tapestry.Scripting/Modules/CommandsModule.cs
+++ b/src/Tapestry.Scripting/Modules/CommandsModule.cs
@@ -240,6 +240,7 @@ public class CommandsModule : IJintApiModule
             roomId = roomId,
             previousRoomId = roomId,
             stats = statsObj,
+            isChargen = ctx.IsChargen,
             hasTag = new Func<string, bool>(tag =>
             {
                 var entity = _world.GetEntity(ctx.PlayerEntityId);

--- a/src/Tapestry.Scripting/Modules/FlowsModule.cs
+++ b/src/Tapestry.Scripting/Modules/FlowsModule.cs
@@ -217,7 +217,10 @@ public class FlowsModule : IJintApiModule
             jint.Invoke(onSelectJs, null, new object[] { entityProxy, optionProxy });
         };
 
-        return new ChoiceStep { Id = id, SkipIf = skipIf, Prompt = prompt, Options = options, OnSelect = onSelect };
+        var helpHintVal = obj.Get("help_hint");
+        var helpHint = helpHintVal.Type == Types.String ? helpHintVal.ToString() : null;
+
+        return new ChoiceStep { Id = id, SkipIf = skipIf, Prompt = prompt, Options = options, OnSelect = onSelect, HelpHint = helpHint };
     }
 
     private TextStep ParseTextStep(JintEngine jint, string id, ObjectInstance obj, Func<Entity, bool>? skipIf)

--- a/src/Tapestry.Scripting/Modules/HelpModule.cs
+++ b/src/Tapestry.Scripting/Modules/HelpModule.cs
@@ -102,8 +102,8 @@ public class HelpModule : IJintApiModule
     // If first arg is not a GUID -> no player, first arg is term.
     internal static (string? entityId, string? term) ResolveArgs(JsValue first, JsValue second)
     {
-        if (first.Type == Types.Undefined || first.Type == Types.Null) { return (null, null); }
-        if (second.Type == Types.Undefined || second.Type == Types.Null)
+        if (first is null || first.Type == Types.Undefined || first.Type == Types.Null) { return (null, null); }
+        if (second is null || second.Type == Types.Undefined || second.Type == Types.Null)
         {
             return (null, first.Type == Types.String ? first.ToString() : null);
         }
@@ -116,6 +116,6 @@ public class HelpModule : IJintApiModule
 
     private static bool IsGuid(JsValue val)
     {
-        return val.Type == Types.String && Guid.TryParse(val.ToString(), out _);
+        return val is not null && val.Type == Types.String && Guid.TryParse(val.ToString(), out _);
     }
 }

--- a/src/Tapestry.Scripting/Modules/HelpModule.cs
+++ b/src/Tapestry.Scripting/Modules/HelpModule.cs
@@ -63,7 +63,7 @@ public class HelpModule : IJintApiModule
     {
         var entityId = IsGuid(first) ? first.ToString() : null;
         var cats = _helpService.Categories(entityId);
-        return engine.Intrinsics.Array.Construct(cats.Select(c => (JsValue)c).ToArray());
+        return engine.Intrinsics.Array.Construct(cats.Select(c => JsValue.FromObject(engine, c)).ToArray());
     }
 
     private static JsValue BuildResult(JintEngine engine, HelpQueryResult result)
@@ -109,7 +109,7 @@ public class HelpModule : IJintApiModule
         }
         if (IsGuid(first))
         {
-            return (first.ToString(), second.Type == Types.String ? second.ToString() : null);
+            return (first.ToString(), second.ToString());
         }
         return (null, first.Type == Types.String ? first.ToString() : null);
     }

--- a/src/Tapestry.Scripting/Modules/HelpModule.cs
+++ b/src/Tapestry.Scripting/Modules/HelpModule.cs
@@ -50,20 +50,28 @@ public class HelpModule : IJintApiModule
     private JsValue ListJs(JintEngine engine, JsValue first, JsValue second)
     {
         var (entityId, category) = ResolveArgs(first, second);
-        if (category == null) { return engine.Intrinsics.Array.Construct(Array.Empty<JsValue>()); }
+        if (category == null) { return BuildArray(engine, Array.Empty<JsValue>()); }
 
         var summaries = _helpService.List(entityId, category);
         var items = summaries
             .Select(s => JsValue.FromObject(engine, new { id = s.Id, title = s.Title, brief = s.Brief }))
             .ToArray();
-        return engine.Intrinsics.Array.Construct(items);
+        return BuildArray(engine, items);
     }
 
     private JsValue CategoriesJs(JintEngine engine, JsValue first)
     {
         var entityId = IsGuid(first) ? first.ToString() : null;
         var cats = _helpService.Categories(entityId);
-        return engine.Intrinsics.Array.Construct(cats.Select(c => JsValue.FromObject(engine, c)).ToArray());
+        return BuildArray(engine, cats.Select(c => JsValue.FromObject(engine, c)).ToArray());
+    }
+
+    // Array.Construct passes items as constructor arguments, so a single item hits
+    // the new Array(singleArg) path where Jint checks if it is a number (length).
+    // JsArray(engine, items) constructs the array directly, bypassing that path.
+    private static JsValue BuildArray(JintEngine engine, JsValue[] items)
+    {
+        return new Jint.Native.JsArray(engine, items);
     }
 
     private static JsValue BuildResult(JintEngine engine, HelpQueryResult result)

--- a/src/Tapestry.Scripting/Modules/HelpModule.cs
+++ b/src/Tapestry.Scripting/Modules/HelpModule.cs
@@ -28,11 +28,15 @@ public class HelpModule : IJintApiModule
     }
 
     // Exposed for unit tests without a live Jint engine
-    public HelpQueryResult QueryDirect(string? entityId, string term) =>
-        _helpService.Query(entityId, term);
+    public HelpQueryResult QueryDirect(string? entityId, string term)
+    {
+        return _helpService.Query(entityId, term);
+    }
 
-    public List<string> CategoriesDirect(string? entityId) =>
-        _helpService.Categories(entityId);
+    public List<string> CategoriesDirect(string? entityId)
+    {
+        return _helpService.Categories(entityId);
+    }
 
     private JsValue QueryJs(JintEngine engine, JsValue first, JsValue second)
     {
@@ -90,12 +94,13 @@ public class HelpModule : IJintApiModule
         brief = t.Brief,
         body = t.Body,
         syntax = t.Syntax.ToArray(),
+        keywords = t.Keywords.ToArray(),
         seeAlso = t.SeeAlso.ToArray()
     };
 
     // If first arg is a GUID -> player context, second arg is term.
     // If first arg is not a GUID -> no player, first arg is term.
-    private static (string? entityId, string? term) ResolveArgs(JsValue first, JsValue second)
+    internal static (string? entityId, string? term) ResolveArgs(JsValue first, JsValue second)
     {
         if (first.Type == Types.Undefined || first.Type == Types.Null) { return (null, null); }
         if (second.Type == Types.Undefined || second.Type == Types.Null)
@@ -109,6 +114,8 @@ public class HelpModule : IJintApiModule
         return (null, first.Type == Types.String ? first.ToString() : null);
     }
 
-    private static bool IsGuid(JsValue val) =>
-        val.Type == Types.String && Guid.TryParse(val.ToString(), out _);
+    private static bool IsGuid(JsValue val)
+    {
+        return val.Type == Types.String && Guid.TryParse(val.ToString(), out _);
+    }
 }

--- a/src/Tapestry.Scripting/Modules/HelpModule.cs
+++ b/src/Tapestry.Scripting/Modules/HelpModule.cs
@@ -1,0 +1,114 @@
+using Jint.Native;
+using Jint.Runtime;
+using Tapestry.Engine.Help;
+using Tapestry.Shared.Help;
+using JintEngine = Jint.Engine;
+
+namespace Tapestry.Scripting.Modules;
+
+public class HelpModule : IJintApiModule
+{
+    private readonly HelpService _helpService;
+
+    public string Namespace => "help";
+
+    public HelpModule(HelpService helpService)
+    {
+        _helpService = helpService;
+    }
+
+    public object Build(JintEngine engine)
+    {
+        return new
+        {
+            query = new Func<JsValue, JsValue, JsValue>((a, b) => QueryJs(engine, a, b)),
+            list = new Func<JsValue, JsValue, JsValue>((a, b) => ListJs(engine, a, b)),
+            categories = new Func<JsValue, JsValue>(a => CategoriesJs(engine, a))
+        };
+    }
+
+    // Exposed for unit tests without a live Jint engine
+    public HelpQueryResult QueryDirect(string? entityId, string term) =>
+        _helpService.Query(entityId, term);
+
+    public List<string> CategoriesDirect(string? entityId) =>
+        _helpService.Categories(entityId);
+
+    private JsValue QueryJs(JintEngine engine, JsValue first, JsValue second)
+    {
+        var (entityId, term) = ResolveArgs(first, second);
+        if (term == null) { return JsValue.Null; }
+
+        var result = _helpService.Query(entityId, term);
+        return BuildResult(engine, result);
+    }
+
+    private JsValue ListJs(JintEngine engine, JsValue first, JsValue second)
+    {
+        var (entityId, category) = ResolveArgs(first, second);
+        if (category == null) { return engine.Intrinsics.Array.Construct(Array.Empty<JsValue>()); }
+
+        var summaries = _helpService.List(entityId, category);
+        var items = summaries
+            .Select(s => JsValue.FromObject(engine, new { id = s.Id, title = s.Title, brief = s.Brief }))
+            .ToArray();
+        return engine.Intrinsics.Array.Construct(items);
+    }
+
+    private JsValue CategoriesJs(JintEngine engine, JsValue first)
+    {
+        var entityId = IsGuid(first) ? first.ToString() : null;
+        var cats = _helpService.Categories(entityId);
+        return engine.Intrinsics.Array.Construct(cats.Select(c => (JsValue)c).ToArray());
+    }
+
+    private static JsValue BuildResult(JintEngine engine, HelpQueryResult result)
+    {
+        object payload = result.Status switch
+        {
+            "ok" => new
+            {
+                status = "ok",
+                topic = result.Topic == null ? null : TopicToAnon(result.Topic)
+            },
+            "multiple" => new
+            {
+                status = "multiple",
+                term = result.Term,
+                matches = result.Matches?.Select(m => new { id = m.Id, title = m.Title, brief = m.Brief }).ToArray()
+            },
+            _ => (object)new { status = "no_match", term = result.Term }
+        };
+        return JsValue.FromObject(engine, payload);
+    }
+
+    private static object TopicToAnon(HelpTopic t) => new
+    {
+        id = t.Id,
+        title = t.Title,
+        category = t.Category,
+        brief = t.Brief,
+        body = t.Body,
+        syntax = t.Syntax.ToArray(),
+        seeAlso = t.SeeAlso.ToArray()
+    };
+
+    // If first arg is a GUID -> player context, second arg is term.
+    // If first arg is not a GUID -> no player, first arg is term.
+    private static (string? entityId, string? term) ResolveArgs(JsValue first, JsValue second)
+    {
+        if (first.Type == Types.Undefined || first.Type == Types.Null) { return (null, null); }
+        if (second.Type == Types.Undefined || second.Type == Types.Null)
+        {
+            return (null, first.Type == Types.String ? first.ToString() : null);
+        }
+        if (IsGuid(first))
+        {
+            return (first.ToString(), second.Type == Types.String ? second.ToString() : null);
+        }
+        return (null, first.Type == Types.String ? first.ToString() : null);
+    }
+
+    private static bool IsGuid(JsValue val) =>
+        val.Type == Types.String && Guid.TryParse(val.ToString(), out _);
+}

--- a/src/Tapestry.Scripting/Modules/UiModule.cs
+++ b/src/Tapestry.Scripting/Modules/UiModule.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Tapestry.Engine.Ui;
@@ -21,7 +22,8 @@ public class UiModule : IJintApiModule
     {
         return new
         {
-            panel = new Func<JsValue, string>(RenderPanel)
+            panel = new Func<JsValue, string>(RenderPanel),
+            help = new Func<JsValue, string>(RenderHelp)
         };
     }
 
@@ -227,5 +229,74 @@ public class UiModule : IJintApiModule
             "center" => Align.Center,
             _ => Align.Left
         };
+    }
+
+    private static string RenderHelp(JsValue specVal)
+    {
+        if (specVal is not ObjectInstance spec) { return ""; }
+
+        var status = spec.Get("status");
+        if (status.Type == Types.Undefined) { return ""; }
+
+        return status.ToString() switch
+        {
+            "ok" => RenderHelpTopic(spec),
+            "multiple" => RenderHelpDisambiguation(spec),
+            "no_match" => HelpRenderer.RenderNoMatch(spec.Get("term")?.ToString() ?? ""),
+            _ => ""
+        };
+    }
+
+    private static string RenderHelpTopic(ObjectInstance spec)
+    {
+        var topicObj = spec.Get("topic");
+        if (topicObj is not ObjectInstance t) { return ""; }
+
+        var topic = new Tapestry.Shared.Help.HelpTopic
+        {
+            Title = t.Get("title")?.ToString() ?? "",
+            Brief = t.Get("brief")?.ToString() ?? "",
+            Body = t.Get("body")?.ToString() ?? "",
+            Syntax = GetStringList(t, "syntax"),
+            SeeAlso = GetStringList(t, "seeAlso")
+        };
+        return HelpRenderer.RenderTopic(topic);
+    }
+
+    private static string RenderHelpDisambiguation(ObjectInstance spec)
+    {
+        var term = spec.Get("term")?.ToString() ?? "";
+        var matchesArr = spec.Get("matches");
+        var matches = new List<Tapestry.Shared.Help.HelpTopicSummary>();
+
+        if (matchesArr is JsArray arr)
+        {
+            for (uint i = 0; i < arr.Length; i++)
+            {
+                if (arr[i] is ObjectInstance m)
+                {
+                    matches.Add(new Tapestry.Shared.Help.HelpTopicSummary
+                    {
+                        Id = m.Get("id")?.ToString() ?? "",
+                        Title = m.Get("title")?.ToString() ?? "",
+                        Brief = m.Get("brief")?.ToString() ?? ""
+                    });
+                }
+            }
+        }
+
+        return HelpRenderer.RenderDisambiguation(term, matches);
+    }
+
+    private static List<string> GetStringList(ObjectInstance obj, string key)
+    {
+        var val = obj.Get(key);
+        if (val is not JsArray arr) { return new(); }
+        var result = new List<string>();
+        for (uint i = 0; i < arr.Length; i++)
+        {
+            result.Add(arr[i].ToString());
+        }
+        return result;
     }
 }

--- a/src/Tapestry.Scripting/PackLoader.cs
+++ b/src/Tapestry.Scripting/PackLoader.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Tapestry.Engine;
 using Tapestry.Engine.Color;
+using Tapestry.Engine.Help;
 using Tapestry.Engine.Inventory;
 using Tapestry.Engine.Items;
 using Tapestry.Engine.Mobs;
@@ -27,6 +28,7 @@ public class PackLoader
     private readonly PackContext _packContext;
     private readonly AreaRegistry _areaRegistry;
     private readonly WeatherZoneRegistry _weatherZoneRegistry;
+    private readonly HelpService _helpService;
     private readonly List<(string RoomId, string ItemId)> _pendingFixtures = new();
     private readonly Dictionary<string, string> _registeredEntityFiles = new();
 
@@ -35,7 +37,8 @@ public class PackLoader
     public PackLoader(World world, SlotRegistry slotRegistry, JintRuntime runtime,
                      ThemeRegistry theme, SpawnManager spawnManager, ItemRegistry itemRegistry,
                      ILogger<PackLoader> logger, PackContext packContext,
-                     AreaRegistry areaRegistry, WeatherZoneRegistry weatherZoneRegistry)
+                     AreaRegistry areaRegistry, WeatherZoneRegistry weatherZoneRegistry,
+                     HelpService helpService)
     {
         _world = world;
         _slotRegistry = slotRegistry;
@@ -47,6 +50,7 @@ public class PackLoader
         _packContext = packContext;
         _areaRegistry = areaRegistry;
         _weatherZoneRegistry = weatherZoneRegistry;
+        _helpService = helpService;
     }
 
     public PackManifest Load(string packDirectory)
@@ -119,6 +123,11 @@ public class PackLoader
         if (!string.IsNullOrEmpty(manifest.Content.Scripts))
         {
             LoadScripts(packDirectory, manifest.Content.Scripts, manifest.Name);
+        }
+
+        if (!string.IsNullOrEmpty(manifest.Content.Help))
+        {
+            _helpService.LoadPack(manifest.Name, packDirectory, manifest.Content.Help, manifest.LoadOrder);
         }
 
         return manifest;

--- a/src/Tapestry.Scripting/ServiceCollectionExtensions.cs
+++ b/src/Tapestry.Scripting/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IJintApiModule, RacesModule>();
         services.AddSingleton<IJintApiModule, AlignmentModule>();
         services.AddSingleton<IJintApiModule, UiModule>();
+        services.AddSingleton<IJintApiModule, HelpModule>();
         services.AddSingleton<IJintApiModule, TrainingModule>();
         services.AddSingleton<IJintApiModule, AdminModule>();
         services.AddSingleton<IJintApiModule, CurrencyModule>();

--- a/src/Tapestry.Scripting/Tapestry.Scripting.csproj
+++ b/src/Tapestry.Scripting/Tapestry.Scripting.csproj
@@ -19,4 +19,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Tapestry.Scripting.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Tapestry.Shared/CommandContext.cs
+++ b/src/Tapestry.Shared/CommandContext.cs
@@ -6,4 +6,5 @@ public class CommandContext
     public required string RawInput { get; init; }
     public required string Command { get; init; }
     public required string[] Args { get; init; }
+    public bool IsChargen { get; init; }
 }

--- a/src/Tapestry.Shared/Help/HelpTopic.cs
+++ b/src/Tapestry.Shared/Help/HelpTopic.cs
@@ -1,0 +1,32 @@
+using YamlDotNet.Serialization;
+
+namespace Tapestry.Shared.Help;
+
+public class HelpTopic
+{
+    public string Id { get; set; } = "";
+    public string Title { get; set; } = "";
+    public string Category { get; set; } = "";
+    public string Brief { get; set; } = "";
+    public string Body { get; set; } = "";
+    public List<string> Syntax { get; set; } = new();
+    public List<string> Keywords { get; set; } = new();
+
+    [YamlMember(Alias = "see_also")]
+    public List<string> SeeAlso { get; set; } = new();
+
+    public string? Role { get; set; }
+
+    [YamlIgnore]
+    public string PackName { get; set; } = "";
+
+    [YamlIgnore]
+    public string NamespacedId => $"{PackName}:{Id}";
+}
+
+public class HelpTopicSummary
+{
+    public string Id { get; set; } = "";
+    public string Title { get; set; } = "";
+    public string Brief { get; set; } = "";
+}

--- a/src/Tapestry.Shared/Help/HelpTopic.cs
+++ b/src/Tapestry.Shared/Help/HelpTopic.cs
@@ -23,10 +23,3 @@ public class HelpTopic
     [YamlIgnore]
     public string NamespacedId => $"{PackName}:{Id}";
 }
-
-public class HelpTopicSummary
-{
-    public string Id { get; set; } = "";
-    public string Title { get; set; } = "";
-    public string Brief { get; set; } = "";
-}

--- a/src/Tapestry.Shared/Help/HelpTopicSummary.cs
+++ b/src/Tapestry.Shared/Help/HelpTopicSummary.cs
@@ -1,0 +1,8 @@
+namespace Tapestry.Shared.Help;
+
+public class HelpTopicSummary
+{
+    public string Id { get; init; } = "";
+    public string Title { get; init; } = "";
+    public string Brief { get; init; } = "";
+}

--- a/src/Tapestry.Shared/PackManifest.cs
+++ b/src/Tapestry.Shared/PackManifest.cs
@@ -29,4 +29,5 @@ public class PackContentPaths
     public string Mobs { get; set; } = "";
     public string AreaDefinitions { get; set; } = "";
     public string WeatherZones { get; set; } = "";
+    public string Help { get; set; } = "";
 }

--- a/src/Tapestry.Shared/Tapestry.Shared.csproj
+++ b/src/Tapestry.Shared/Tapestry.Shared.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Tapestry.Engine.Tests/Flow/FlowInstanceTests.cs
+++ b/tests/Tapestry.Engine.Tests/Flow/FlowInstanceTests.cs
@@ -237,73 +237,65 @@ public class FlowInstanceTests
     }
 
     [Fact]
-    public void ChoiceStep_bare_question_mark_shows_hint_message()
+    public void ChoiceStep_bare_question_mark_routes_to_help_command()
     {
+        string? routed = null;
         var (instance, session, conn) = Setup(
             new ChoiceStep
             {
                 Id = "c",
                 Prompt = _ => "Choose:",
-                Options = _ => new[]
-                {
-                    new ChoiceOption("Human", "human", _ => "Adaptable and ambitious."),
-                    new ChoiceOption("Andoran", "folk", _ => "Children of the Light.")
-                },
+                Options = _ => new[] { new ChoiceOption("Human", "human") },
                 OnSelect = (_, _) => { }
             });
+        instance.CommandFallback = cmd => { routed = cmd; };
 
         instance.Start(session);
         instance.HandleInput("?");
 
-        conn.SentText.Should().Contain(s => s.Contains("? [option]") || s.Contains("learn more"));
-        conn.SentText.Should().NotContain(s => s.Contains("Adaptable and ambitious."));
+        routed.Should().Be("help");
         instance.CurrentStepIndex.Should().Be(0);
     }
 
     [Fact]
-    public void ChoiceStep_bare_help_shows_hint_message()
+    public void ChoiceStep_bare_help_routes_to_help_command()
     {
+        string? routed = null;
         var (instance, session, conn) = Setup(
             new ChoiceStep
             {
                 Id = "c",
                 Prompt = _ => "Choose:",
-                Options = _ => new[]
-                {
-                    new ChoiceOption("Human", "human", _ => "Adaptable and ambitious.")
-                },
+                Options = _ => new[] { new ChoiceOption("Human", "human") },
                 OnSelect = (_, _) => { }
             });
+        instance.CommandFallback = cmd => { routed = cmd; };
 
         instance.Start(session);
         instance.HandleInput("help");
 
-        conn.SentText.Should().Contain(s => s.Contains("? [option]") || s.Contains("learn more"));
-        conn.SentText.Should().NotContain(s => s.Contains("Adaptable and ambitious."));
+        routed.Should().Be("help");
         instance.CurrentStepIndex.Should().Be(0);
     }
 
     [Fact]
-    public void ChoiceStep_help_with_number_shows_description_for_that_option()
+    public void ChoiceStep_question_with_term_routes_to_help_with_term()
     {
+        string? routed = null;
         var (instance, session, conn) = Setup(
             new ChoiceStep
             {
                 Id = "c",
                 Prompt = _ => "Choose:",
-                Options = _ => new[]
-                {
-                    new ChoiceOption("Human", "human", _ => "Adaptable and ambitious."),
-                    new ChoiceOption("Andoran", "folk", _ => "Children of the Light.")
-                },
+                Options = _ => new[] { new ChoiceOption("Human", "human") },
                 OnSelect = (_, _) => { }
             });
+        instance.CommandFallback = cmd => { routed = cmd; };
 
         instance.Start(session);
-        instance.HandleInput("? 2");
+        instance.HandleInput("? races");
 
-        conn.SentText.Should().Contain(s => s.Contains("Children of the Light."));
-        conn.SentText.Should().NotContain(s => s.Contains("Adaptable and ambitious."));
+        routed.Should().Be("help races");
         instance.CurrentStepIndex.Should().Be(0);
     }
 
@@ -321,77 +313,31 @@ public class FlowInstanceTests
 
         instance.Start(session);
 
-        conn.SentText.Should().Contain(s => s.Contains("? [option]") || s.Contains("for details"));
+        conn.SentText.Should().Contain(s => s.Contains("help") && s.Contains("for details"));
     }
 
     [Fact]
-    public void ChoiceStep_help_with_name_shows_matching_description()
+    public void ChoiceStep_rendered_prompt_uses_help_hint_when_set()
     {
         var (instance, session, conn) = Setup(
             new ChoiceStep
             {
                 Id = "c",
                 Prompt = _ => "Choose:",
-                Options = _ => new[]
-                {
-                    new ChoiceOption("Human", "human", _ => "Adaptable and ambitious."),
-                    new ChoiceOption("Andoran", "folk", _ => "Children of the Light.")
-                },
-                OnSelect = (_, _) => { }
+                Options = _ => new[] { new ChoiceOption("Human", "human") },
+                OnSelect = (_, _) => { },
+                HelpHint = "races"
             });
 
         instance.Start(session);
-        instance.HandleInput("? Human");
 
-        conn.SentText.Should().Contain(s => s.Contains("Adaptable and ambitious."));
-        conn.SentText.Should().NotContain(s => s.Contains("Children of the Light."));
-        instance.CurrentStepIndex.Should().Be(0);
+        conn.SentText.Should().Contain(s => s.Contains("help races") && s.Contains("for details"));
     }
 
     [Fact]
-    public void ChoiceStep_help_prefix_is_case_insensitive()
+    public void ChoiceStep_help_with_term_routes_regardless_of_option_match()
     {
-        var (instance, session, conn) = Setup(
-            new ChoiceStep
-            {
-                Id = "c",
-                Prompt = _ => "Choose:",
-                Options = _ => new[]
-                {
-                    new ChoiceOption("Human", "human", _ => "Adaptable and ambitious.")
-                },
-                OnSelect = (_, _) => { }
-            });
-
-        instance.Start(session);
-        instance.HandleInput("HELP HUMAN");
-
-        conn.SentText.Should().Contain(s => s.Contains("Adaptable and ambitious."));
-        instance.CurrentStepIndex.Should().Be(0);
-    }
-
-    [Fact]
-    public void ChoiceStep_help_unknown_option_sends_unknown_message()
-    {
-        var (instance, session, conn) = Setup(
-            new ChoiceStep
-            {
-                Id = "c",
-                Prompt = _ => "Choose:",
-                Options = _ => new[] { new ChoiceOption("Human", "human", _ => "Warriors.") },
-                OnSelect = (_, _) => { }
-            });
-
-        instance.Start(session);
-        instance.HandleInput("? Elf");
-
-        conn.SentText.Should().Contain(s => s.Contains("Unknown option: Elf"));
-        instance.CurrentStepIndex.Should().Be(0);
-    }
-
-    [Fact]
-    public void ChoiceStep_help_option_without_description_sends_fallback()
-    {
+        string? routed = null;
         var (instance, session, conn) = Setup(
             new ChoiceStep
             {
@@ -400,11 +346,33 @@ public class FlowInstanceTests
                 Options = _ => new[] { new ChoiceOption("Human", "human") },
                 OnSelect = (_, _) => { }
             });
+        instance.CommandFallback = cmd => { routed = cmd; };
 
         instance.Start(session);
-        instance.HandleInput("? Human");
+        instance.HandleInput("? Elf");
 
-        conn.SentText.Should().Contain(s => s.Contains("No additional information available for Human."));
+        routed.Should().Be("help Elf");
+        instance.CurrentStepIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void ChoiceStep_help_prefix_routes_full_input_to_fallback()
+    {
+        string? routed = null;
+        var (instance, session, conn) = Setup(
+            new ChoiceStep
+            {
+                Id = "c",
+                Prompt = _ => "Choose:",
+                Options = _ => new[] { new ChoiceOption("Human", "human") },
+                OnSelect = (_, _) => { }
+            });
+        instance.CommandFallback = cmd => { routed = cmd; };
+
+        instance.Start(session);
+        instance.HandleInput("help races");
+
+        routed.Should().Be("help races");
         instance.CurrentStepIndex.Should().Be(0);
     }
 
@@ -685,8 +653,9 @@ public class FlowInstanceTests
     }
 
     [Fact]
-    public void WizardPanel_help_query_does_not_clear_screen()
+    public void WizardPanel_help_query_routes_to_command_fallback()
     {
+        string? routed = null;
         var (instance, session, conn) = SetupWizard(
             new[] { new WizardStep("c", "Race") },
             new ChoiceStep
@@ -699,12 +668,13 @@ public class FlowInstanceTests
                 },
                 OnSelect = (_, _) => { }
             });
+        instance.CommandFallback = cmd => { routed = cmd; };
 
         instance.Start(session);
         conn.SentText.Clear();
         instance.HandleInput("? Human");
 
-        conn.SentText.Should().Contain(s => s.Contains("Adaptable and ambitious."));
-        conn.SentText.Should().NotContain(s => s.Contains("\x1b[2J"));
+        routed.Should().Be("help Human");
+        conn.SentText.Should().NotContain(s => s.Contains("Adaptable and ambitious."));
     }
 }

--- a/tests/Tapestry.Engine.Tests/Help/HelpServiceTests.cs
+++ b/tests/Tapestry.Engine.Tests/Help/HelpServiceTests.cs
@@ -1,0 +1,180 @@
+using Tapestry.Engine.Help;
+using Tapestry.Shared.Help;
+using Xunit;
+
+namespace Tapestry.Engine.Tests.Help;
+
+public class HelpServiceTests
+{
+    private static HelpTopic MakeTopic(
+        string id,
+        string packName = "test-pack",
+        string? role = null,
+        string category = "general",
+        string[]? keywords = null) =>
+        new()
+        {
+            Id = id,
+            PackName = packName,
+            Title = id.Replace('-', ' '),
+            Category = category,
+            Brief = $"Brief for {id}",
+            Body = $"Body for {id}",
+            Role = role,
+            Keywords = keywords?.ToList() ?? new()
+        };
+
+    [Fact]
+    public void Query_ExactIdMatch_ReturnsOk()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics"));
+
+        var result = svc.Query(null, "combat-basics");
+
+        Assert.Equal("ok", result.Status);
+        Assert.Equal("combat-basics", result.Topic!.Id);
+    }
+
+    [Fact]
+    public void Query_NamespacedId_ReturnsOk()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics", "example-pack"));
+
+        var result = svc.Query(null, "example-pack:combat-basics");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void Query_TitleCaseInsensitive_ReturnsOk()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("races"));
+
+        var result = svc.Query(null, "RACES");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void Query_HigherLoadOrderWins_OnCollision()
+    {
+        var svc = new HelpService();
+        var low = MakeTopic("combat-basics", "pack-a");
+        low.Title = "Original";
+        var high = MakeTopic("combat-basics", "pack-b");
+        high.Title = "Override";
+
+        svc.AddTopic(low, loadOrder: 10);
+        svc.AddTopic(high, loadOrder: 20);
+
+        var result = svc.Query(null, "combat-basics");
+        Assert.Equal("Override", result.Topic!.Title);
+    }
+
+    [Fact]
+    public void Query_NoMatch_ReturnsNoMatchStatus()
+    {
+        var svc = new HelpService();
+        var result = svc.Query(null, "xyzzy");
+        Assert.Equal("no_match", result.Status);
+        Assert.Equal("xyzzy", result.Term);
+    }
+
+    [Fact]
+    public void Query_MultipleKeywordMatches_ReturnsMultiple()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics", keywords: new[] { "fighting" }));
+        svc.AddTopic(MakeTopic("combat-advanced", keywords: new[] { "fighting" }));
+
+        var result = svc.Query(null, "fighting");
+
+        Assert.Equal("multiple", result.Status);
+        Assert.Equal(2, result.Matches!.Count);
+    }
+
+    [Fact]
+    public void Query_SingleKeywordMatch_ReturnsOk()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics", keywords: new[] { "fighting" }));
+
+        var result = svc.Query(null, "fighting");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void RoleFilter_NoPlayer_HidesPlayerTopics()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics", role: "player"));
+
+        var result = svc.Query(null, "combat-basics");
+
+        Assert.Equal("no_match", result.Status);
+    }
+
+    [Fact]
+    public void RoleFilter_NoPlayer_ShowsRolelessTopics()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("races")); // no role
+
+        var result = svc.Query(null, "races");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void RoleFilter_WithPlayer_ShowsPlayerTopics()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics", role: "player"));
+
+        var result = svc.Query(Guid.NewGuid().ToString(), "combat-basics");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void Categories_ReturnsDistinctSortedList()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat", category: "combat"));
+        svc.AddTopic(MakeTopic("combat-basics", category: "combat"));
+        svc.AddTopic(MakeTopic("races", category: "chargen"));
+
+        var cats = svc.Categories(null);
+
+        Assert.Contains("chargen", cats);
+        Assert.Contains("combat", cats);
+        Assert.Equal(2, cats.Count);
+    }
+
+    [Fact]
+    public void List_ReturnsSummariesForCategory()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat", category: "combat"));
+        svc.AddTopic(MakeTopic("combat-basics", category: "combat"));
+
+        var list = svc.List(null, "combat");
+
+        Assert.Equal(2, list.Count);
+    }
+
+    [Fact]
+    public void List_RoleFilter_HidesPlayerTopics_WhenNoPlayer()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("combat-basics", category: "combat", role: "player"));
+
+        var list = svc.List(null, "combat");
+
+        Assert.Empty(list);
+    }
+}

--- a/tests/Tapestry.Engine.Tests/Help/HelpServiceTests.cs
+++ b/tests/Tapestry.Engine.Tests/Help/HelpServiceTests.cs
@@ -177,4 +177,29 @@ public class HelpServiceTests
 
         Assert.Empty(list);
     }
+
+    [Fact]
+    public void List_RolelessTopic_VisibleToPlayer()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("races", category: "creation"));
+
+        var list = svc.List(Guid.NewGuid().ToString(), "creation");
+
+        Assert.Single(list);
+    }
+
+    [Fact]
+    public void Categories_And_List_Consistent_For_Roleless_Topic()
+    {
+        var svc = new HelpService();
+        svc.AddTopic(MakeTopic("races", category: "creation"));
+
+        var entityId = Guid.NewGuid().ToString();
+        var cats = svc.Categories(entityId);
+        var list = svc.List(entityId, "creation");
+
+        Assert.Contains("creation", cats);
+        Assert.Single(list);
+    }
 }

--- a/tests/Tapestry.Engine.Tests/Ui/HelpRendererTests.cs
+++ b/tests/Tapestry.Engine.Tests/Ui/HelpRendererTests.cs
@@ -63,4 +63,11 @@ public class HelpRendererTests
         var output = HelpRenderer.RenderDisambiguation("x", matches, 60);
         Assert.Contains("Multiple matches", output);
     }
+
+    [Fact]
+    public void RenderNoMatch_ContainsTerm()
+    {
+        var output = HelpRenderer.RenderNoMatch("xyzzy");
+        Assert.Contains("xyzzy", output);
+    }
 }

--- a/tests/Tapestry.Engine.Tests/Ui/HelpRendererTests.cs
+++ b/tests/Tapestry.Engine.Tests/Ui/HelpRendererTests.cs
@@ -1,0 +1,66 @@
+using Tapestry.Engine.Ui;
+using Tapestry.Shared.Help;
+using Xunit;
+
+namespace Tapestry.Engine.Tests.Ui;
+
+public class HelpRendererTests
+{
+    [Fact]
+    public void RenderTopic_ContainsTitle()
+    {
+        var topic = new HelpTopic { Title = "Combat Basics", Brief = "Fight stuff.", Body = "Body here." };
+        var output = HelpRenderer.RenderTopic(topic, 60);
+        Assert.Contains("Combat Basics", output);
+    }
+
+    [Fact]
+    public void RenderTopic_ContainsBrief()
+    {
+        var topic = new HelpTopic { Title = "X", Brief = "Fight stuff.", Body = "B." };
+        var output = HelpRenderer.RenderTopic(topic, 60);
+        Assert.Contains("Fight stuff.", output);
+    }
+
+    [Fact]
+    public void RenderTopic_ContainsSyntaxLines()
+    {
+        var topic = new HelpTopic { Title = "X", Brief = "B.", Body = "Body.", Syntax = new() { "kill [target]", "flee" } };
+        var output = HelpRenderer.RenderTopic(topic, 60);
+        Assert.Contains("kill [target]", output);
+        Assert.Contains("flee", output);
+    }
+
+    [Fact]
+    public void RenderTopic_ContainsSeeAlso()
+    {
+        var topic = new HelpTopic { Title = "X", Brief = "B.", Body = "Body.", SeeAlso = new() { "combat-advanced" } };
+        var output = HelpRenderer.RenderTopic(topic, 60);
+        Assert.Contains("combat-advanced", output);
+    }
+
+    [Fact]
+    public void RenderDisambiguation_ContainsAllMatches()
+    {
+        var matches = new List<HelpTopicSummary>
+        {
+            new() { Id = "combat-basics", Title = "Combat Basics", Brief = "..." },
+            new() { Id = "combat-advanced", Title = "Advanced Combat", Brief = "..." }
+        };
+        var output = HelpRenderer.RenderDisambiguation("combat", matches, 60);
+        Assert.Contains("combat-basics", output);
+        Assert.Contains("combat-advanced", output);
+    }
+
+    [Fact]
+    public void RenderDisambiguation_ContainsMultipleMatchesLabel()
+    {
+        var matches = new List<HelpTopicSummary>
+        {
+            new() { Id = "a", Title = "A", Brief = "." },
+            new() { Id = "b", Title = "B", Brief = "." }
+        };
+        var output = HelpRenderer.RenderDisambiguation("x", matches, 60);
+        Assert.Contains("Multiple matches", output);
+    }
+}

--- a/tests/Tapestry.Scripting.Tests/Modules/HelpModuleTests.cs
+++ b/tests/Tapestry.Scripting.Tests/Modules/HelpModuleTests.cs
@@ -1,0 +1,67 @@
+using Tapestry.Engine.Help;
+using Tapestry.Scripting.Modules;
+using Tapestry.Shared.Help;
+
+namespace Tapestry.Scripting.Tests.Modules;
+
+public class HelpModuleTests
+{
+    private static HelpService BuildService(params (string id, string? role)[] topics)
+    {
+        var svc = new HelpService();
+        foreach (var (id, role) in topics)
+        {
+            svc.AddTopic(new HelpTopic
+            {
+                Id = id,
+                PackName = "test",
+                Title = id,
+                Category = "general",
+                Brief = $"Brief for {id}",
+                Body = $"Body for {id}",
+                Role = role
+            });
+        }
+        return svc;
+    }
+
+    [Fact]
+    public void Namespace_IsHelp()
+    {
+        var module = new HelpModule(new HelpService());
+        Assert.Equal("help", module.Namespace);
+    }
+
+    [Fact]
+    public void QueryDirect_NoPlayer_ReturnsRolelessTopic()
+    {
+        var svc = BuildService(("races", null));
+        var module = new HelpModule(svc);
+
+        var result = module.QueryDirect(null, "races");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void QueryDirect_WithGuid_ReturnsPlayerTopic()
+    {
+        var svc = BuildService(("combat", "player"));
+        var module = new HelpModule(svc);
+
+        var result = module.QueryDirect(Guid.NewGuid().ToString(), "combat");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void CategoriesDirect_ReturnsList()
+    {
+        var svc = BuildService(("races", null));
+        var module = new HelpModule(svc);
+
+        var cats = module.CategoriesDirect(null);
+
+        Assert.Contains("general", cats);
+    }
+}

--- a/tests/Tapestry.Scripting.Tests/Modules/HelpModuleTests.cs
+++ b/tests/Tapestry.Scripting.Tests/Modules/HelpModuleTests.cs
@@ -1,3 +1,4 @@
+using Jint.Native;
 using Tapestry.Engine.Help;
 using Tapestry.Scripting.Modules;
 using Tapestry.Shared.Help;
@@ -63,5 +64,32 @@ public class HelpModuleTests
         var cats = module.CategoriesDirect(null);
 
         Assert.Contains("general", cats);
+    }
+
+    [Fact]
+    public void ResolveArgs_GuidFirstArg_ReturnsEntityIdAndTerm()
+    {
+        var guid = Guid.NewGuid().ToString();
+        var engine = new Jint.Engine();
+        var first = JsValue.FromObject(engine, guid);
+        var second = JsValue.FromObject(engine, "combat");
+
+        var (entityId, term) = HelpModule.ResolveArgs(first, second);
+
+        Assert.Equal(guid, entityId);
+        Assert.Equal("combat", term);
+    }
+
+    [Fact]
+    public void ResolveArgs_NonGuidFirstArg_ReturnsTerm()
+    {
+        var engine = new Jint.Engine();
+        var first = JsValue.FromObject(engine, "races");
+        var second = JsValue.Undefined;
+
+        var (entityId, term) = HelpModule.ResolveArgs(first, second);
+
+        Assert.Null(entityId);
+        Assert.Equal("races", term);
     }
 }

--- a/tests/Tapestry.Scripting.Tests/PackLoaderTests.cs
+++ b/tests/Tapestry.Scripting.Tests/PackLoaderTests.cs
@@ -268,8 +268,9 @@ public class PackLoaderTests
         };
 
         var runtime = new JintRuntime(modules, NullLogger<JintRuntime>.Instance);
+        var helpService = new Tapestry.Engine.Help.HelpService();
         var loader = new PackLoader(world, slotRegistry, runtime, themeRegistry, spawnManager, itemRegistry,
-            NullLogger<PackLoader>.Instance, packContext, areaRegistry, weatherZoneRegistry);
+            NullLogger<PackLoader>.Instance, packContext, areaRegistry, weatherZoneRegistry, helpService);
 
         return (world, itemRegistry, spawnManager, loader);
     }

--- a/tests/scenarios/commands/help.scenario.txt
+++ b/tests/scenarios/commands/help.scenario.txt
@@ -9,7 +9,7 @@
 1. Connect without logging in (session is in Creating phase, no player entity)
 2. Send: `help`
 3. Assert sees: `chargen`
-4. Assert does NOT see: `combat`
+4. Assert does not see: `combat`
 
 ### Notes
 - All combat topics have role:player. Chargen context has no role, so
@@ -37,7 +37,7 @@
 ### Steps
 1. Connect without logging in
 2. Send: `help combat-basics`
-3. Assert sees: `No help found for 'combat-basics'`
+3. Assert sees: `No help found for 'combat-basics'.`
 
 ### Notes
 - combat-basics.yaml has role:player. Without a player entity, the topic
@@ -78,7 +78,7 @@
 
 ### Steps
 1. Wanderer: `help xyzzy`
-2. Assert Wanderer sees: `No help found for 'xyzzy'`
+2. Assert Wanderer sees: `No help found for 'xyzzy'.`
 
 ---
 
@@ -89,8 +89,8 @@
 1. Wanderer: `help combat`
 2. Assert Wanderer sees: `Combat`
 3. Assert Wanderer sees: `combat-basics`
-4. Assert Wanderer does NOT see: `disambiguation`
-5. Assert Wanderer does NOT see: `Did you mean`
+4. Assert Wanderer does not see: `disambiguation`
+5. Assert Wanderer does not see: `Did you mean`
 
 ### Notes
 - "combat" is an exact topic ID. The resolver must match it directly

--- a/tests/scenarios/commands/help.scenario.txt
+++ b/tests/scenarios/commands/help.scenario.txt
@@ -1,0 +1,114 @@
+# help command
+# Tests role-filtered TOC, topic lookup, exact ID match, fuzzy keyword match,
+# and "no match" error message -- covering chargen and player contexts.
+
+## Scenario: Chargen TOC shows chargen category, not combat
+- Players: (none -- pre-login chargen context)
+
+### Steps
+1. Connect without logging in (session is in Creating phase, no player entity)
+2. Send: `help`
+3. Assert sees: `chargen`
+4. Assert does NOT see: `combat`
+
+### Notes
+- All combat topics have role:player. Chargen context has no role, so
+  role:player topics must be filtered out.
+- Expected: category list contains "chargen", omits "combat".
+
+---
+
+## Scenario: Chargen topic with no role requirement renders
+- Players: (none -- pre-login chargen context)
+
+### Steps
+1. Connect without logging in
+2. Send: `help races`
+3. Assert sees: `Choosing a Race`
+
+### Notes
+- races.yaml has no role field -- available in all contexts.
+
+---
+
+## Scenario: Chargen context blocks player-only topic
+- Players: (none -- pre-login chargen context)
+
+### Steps
+1. Connect without logging in
+2. Send: `help combat-basics`
+3. Assert sees: `No help found for 'combat-basics'`
+
+### Notes
+- combat-basics.yaml has role:player. Without a player entity, the topic
+  must be invisible and return the "no match" message.
+
+---
+
+## Scenario: Player TOC includes both combat and chargen
+- Players: Wanderer
+
+### Steps
+1. Wanderer: `help`
+2. Assert Wanderer sees: `combat`
+3. Assert Wanderer sees: `chargen`
+
+### Notes
+- Logged-in player has role:player, so all categories visible.
+
+---
+
+## Scenario: Player retrieves player-only topic
+- Players: Wanderer
+
+### Steps
+1. Wanderer: `help combat-basics`
+2. Assert Wanderer sees: `Combat Basics`
+3. Assert Wanderer sees: `kill [target]`
+4. Assert Wanderer sees: `flee`
+5. Assert Wanderer sees: `Combat begins when you attack`
+
+### Notes
+- Verifies title, syntax block, and body all render.
+
+---
+
+## Scenario: Player gets no-match message for unknown topic
+- Players: Wanderer
+
+### Steps
+1. Wanderer: `help xyzzy`
+2. Assert Wanderer sees: `No help found for 'xyzzy'`
+
+---
+
+## Scenario: Exact ID match returns overview topic directly
+- Players: Wanderer
+
+### Steps
+1. Wanderer: `help combat`
+2. Assert Wanderer sees: `Combat`
+3. Assert Wanderer sees: `combat-basics`
+4. Assert Wanderer does NOT see: `disambiguation`
+5. Assert Wanderer does NOT see: `Did you mean`
+
+### Notes
+- "combat" is an exact topic ID. The resolver must match it directly
+  and render the combat.yaml overview, not a disambiguation list.
+- see_also should include "combat-basics" per the topic definition.
+
+---
+
+## Scenario: Fuzzy keyword single match returns topic directly
+- Players: Wanderer
+
+### Steps
+1. Wanderer: `help fighting`
+2. Assert Wanderer sees: `Combat Basics`
+
+### Notes
+- "fighting" is a keyword on combat-basics.yaml. It is the only topic
+  in example-pack with that keyword, so the resolver returns it directly
+  without a disambiguation prompt.
+- If a second "fighting" keyword topic is added later, this scenario
+  should be updated to test disambiguation instead.


### PR DESCRIPTION
## Summary

- **Help system**: Pack authors write YAML topics (`id`, `title`, `category`, `brief`, `body`, `keywords`, `see_also`, `role`). Engine loads them on startup; higher load-order packs override lower.
- **Role filtering**: Topics with no `role` are visible to all (including chargen). `role: player` requires an active session; `role: builder` / `role: admin` require elevated access.
- **Query modes**: exact id, namespaced id (`pack:id`), title (case-insensitive), keyword fuzzy match. Multiple matches return a disambiguation list.
- **`help` command** (tapestry-core): browse TOC by category, query single topics, GMCP `Response.Help` events.
- **Chargen integration**: `?` and `help [term]` route through the real help system during character creation. Context-aware footer hints (`help races`, `help gender`, `help classes`) via `help_hint` on choice steps. Player-role topics are invisible during chargen (session phase gating via `isChargen` on the player proxy).
- **UI renderer**: `HelpRenderer` formats topics in an ANSI panel with title, brief, body, syntax, and see-also. Graceful ASCII fallback for non-ANSI connections.
- **Scripting API**: `tapestry.help.query(entityId?, term)`, `tapestry.help.list(entityId?, category)`, `tapestry.help.categories(entityId?)`.

## Bug fixes during playtesting

- `━` multi-byte Unicode rule character swapped for ASCII `=` (rendered as garbage in telnet clients).
- `help` / `?` were intercepted by the chargen flow instead of routing to the help system.
- `Array.Construct([singleItem])` in Jint hits the `new Array(length)` constructor path for 1-element results -- switched to `new JsArray(engine, items[])` which bypasses the constructor dispatch entirely.
- `categories()` / `list()` / `query()` called with fewer args than the delegate signature caused C# null `JsValue` NullReferenceExceptions -- added null guards to `IsGuid` and `ResolveArgs`.
- Player-role topics visible during chargen because entity already has a GUID -- `CommandContext.IsChargen` (set from `session.Phase`) now gates help queries to role-less topics only.

## Test plan

- [x] `help` in chargen shows only creation-category topics (no combat, no player-role topics)
- [x] `help races` / `help classes` return topic details during chargen
- [x] `?` and `help [term]` route correctly during chargen wizard
- [x] Wizard panel footer shows context-aware hint (`help races`, `help gender`, `help classes`)
- [x] `help combat` works after chargen completes (player session)
- [x] `help` TOC shows correct topic counts for all categories (including single-topic categories)
- [x] Multi-keyword match returns disambiguation list
- [x] GMCP `Response.Help` fires on query

🤖 Generated with [Claude Code](https://claude.com/claude-code)