### PR TITLE
Pack-driven help YAML files with NVDA screen reader fixes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import { initCoreHandlers } from './connection/GmcpDispatcher'
 import { useShortcutStore } from './stores/shortcutStore'
 import { registerAllShortcuts } from './accessibility/shortcuts/registerAll'
 import { HelpModal } from './panels/HelpModal'
+import { useHelpStore } from './stores/helpStore'
 
 initCoreHandlers()
 registerAllShortcuts()
@@ -17,6 +18,7 @@ export default function App() {
   const status = useConnectionStore((s) => s.status)
   const loginPhase = useConnectionStore((s) => s.loginPhase)
   const toggleDebug = useDebugStore((s) => s.toggleOpen)
+  const helpDialogKey = useHelpStore((s) => s.dialogKey)
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -56,7 +58,7 @@ export default function App() {
     return (
       <>
         {/* Mounted at App level (not inside GameLayout) so it's available during chargen */}
-        <HelpModal />
+        <HelpModal key={helpDialogKey} />
         <GameLayout />
       </>
     )

--- a/client/src/accessibility/shortcuts/helpTopic.ts
+++ b/client/src/accessibility/shortcuts/helpTopic.ts
@@ -1,23 +1,22 @@
 import { useHelpStore } from '../../stores/helpStore'
-import { useAnnounceStore } from '../announceStore'
 import { stripMarkup } from '../../utils/text'
 
 export function handleHelpTopic(): void {
-  const { response, isOpen } = useHelpStore.getState()
+  const { response, isOpen, pushAnnouncement } = useHelpStore.getState()
   if (!isOpen || !response) { return }
 
   if (response.status === 'ok') {
     const topic = response.topic
-    const parts: string[] = [topic.brief]
+    const parts: string[] = []
     if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
-    if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
     parts.push(topic.body)
-    useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')
+    if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
+    pushAnnouncement(stripMarkup(parts.join('. ')))
   } else if (response.status === 'multiple') {
     const titles = response.matches.map((m) => m.title).join(', ')
     const label = response.term
       ? `Multiple matches for "${response.term}": ${titles}. Type help [topic] for details.`
       : `Help categories: ${titles}. Type help [category] to browse.`
-    useAnnounceStore.getState().pushMessage(label, 'assertive')
+    pushAnnouncement(label)
   }
 }

--- a/client/src/accessibility/shortcuts/helpTopic.ts
+++ b/client/src/accessibility/shortcuts/helpTopic.ts
@@ -4,11 +4,20 @@ import { stripMarkup } from '../../utils/text'
 
 export function handleHelpTopic(): void {
   const { response, isOpen } = useHelpStore.getState()
-  if (!isOpen || !response || response.status !== 'ok') { return }
-  const topic = response.topic
-  const parts: string[] = [topic.brief]
-  if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
-  if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
-  parts.push(topic.body)
-  useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')
+  if (!isOpen || !response) { return }
+
+  if (response.status === 'ok') {
+    const topic = response.topic
+    const parts: string[] = [topic.brief]
+    if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
+    if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
+    parts.push(topic.body)
+    useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')
+  } else if (response.status === 'multiple') {
+    const titles = response.matches.map((m) => m.title).join(', ')
+    const label = response.term
+      ? `Multiple matches for "${response.term}": ${titles}. Type help [topic] for details.`
+      : `Help categories: ${titles}. Type help [category] to browse.`
+    useAnnounceStore.getState().pushMessage(label, 'assertive')
+  }
 }

--- a/client/src/panels/HelpModal.test.tsx
+++ b/client/src/panels/HelpModal.test.tsx
@@ -34,7 +34,7 @@ describe('HelpModal', () => {
         })
         render(<HelpModal />)
         expect(screen.getByText('Combat')).toBeTruthy()
-        expect(screen.getByText('Fight stuff.')).toBeTruthy()
+        expect(screen.getByText('Fight stuff.', { selector: 'p' })).toBeTruthy()
     })
 
     it('renders disambiguation list when opened with multiple response', () => {

--- a/client/src/panels/HelpModal.tsx
+++ b/client/src/panels/HelpModal.tsx
@@ -24,12 +24,18 @@ export function HelpModal() {
     }, [isOpen])
 
     useEffect(() => {
-        if (!isOpen || !response || response.status !== 'ok') { return }
-        const topic = response.topic
-        const parts: string[] = [topic.brief]
-        if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
-        if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
-        useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'polite')
+        if (!isOpen || !response) { return }
+        if (response.status === 'ok') {
+            const topic = response.topic
+            const parts: string[] = [topic.brief]
+            if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
+            if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
+            useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')
+        } else if (response.status === 'multiple') {
+            const titles = response.matches.map((m) => m.title).join(', ')
+            const label = response.term ? `Multiple matches for "${response.term}": ${titles}` : `Help categories: ${titles}`
+            useAnnounceStore.getState().pushMessage(label, 'assertive')
+        }
     }, [isOpen, response])
 
     useEffect(() => {
@@ -52,9 +58,11 @@ export function HelpModal() {
                         <h2 className="text-lg font-semibold">
                             {response.status === 'ok'
                                 ? response.topic.title
-                                : response.status === 'multiple' || response.status === 'no_match'
-                                    ? `Help: "${response.term}"`
-                                    : ''}
+                                : response.status === 'multiple'
+                                    ? (response.term ? `Help: "${response.term}"` : 'Help Topics')
+                                    : response.status === 'no_match'
+                                        ? `Help: "${response.term}"`
+                                        : ''}
                         </h2>
                         <button
                             onClick={closeHelp}
@@ -124,7 +132,9 @@ function HelpTopicContent({ topic }: { topic: HelpTopicData }) {
 function HelpDisambiguation({ term, matches }: { term: string; matches: HelpTopicSummary[] }) {
     return (
         <div className="space-y-2">
-            <p className="text-gray-400 text-sm">Multiple topics match "{term}":</p>
+            <p className="text-gray-400 text-sm">
+                {term ? `Multiple topics match "${term}":` : 'Browse a category or type help [topic]:'}
+            </p>
             <ul className="space-y-1">
                 {matches.map((m) => (
                     <li key={m.id}>

--- a/client/src/panels/HelpModal.tsx
+++ b/client/src/panels/HelpModal.tsx
@@ -1,61 +1,54 @@
 import { useEffect, useRef } from 'react'
 import { useHelpStore, type HelpTopicData, type HelpTopicSummary } from '../stores/helpStore'
-import { parseColorTags, stripMarkup } from '../utils/text'
-import { useAnnounceStore } from '../accessibility/announceStore'
+import { parseColorTags } from '../utils/text'
 import { WebSocketClient } from '../connection/WebSocketClient'
 
+let savedFocus: Element | null = null
+
 export function HelpModal() {
-    const { isOpen, response, closeHelp } = useHelpStore()
+    const { isOpen, response, closeHelp, inDialogKey, inDialogAnnouncement } = useHelpStore()
     const dialogRef = useRef<HTMLDialogElement>(null)
-    const previousFocusRef = useRef<Element | null>(null)
+    const headingRef = useRef<HTMLHeadingElement>(null)
 
     useEffect(() => {
         const dialog = dialogRef.current
         if (!dialog) { return }
         if (isOpen) {
-            previousFocusRef.current = document.activeElement
+            if (!savedFocus) { savedFocus = document.activeElement }
             dialog.showModal()
         } else {
             dialog.close()
-            if (previousFocusRef.current instanceof HTMLElement) {
-                previousFocusRef.current.focus()
-            }
+            if (savedFocus instanceof HTMLElement) { savedFocus.focus() }
+            savedFocus = null
         }
     }, [isOpen])
 
+    // Prevent native <dialog> Escape from closing without updating React state
+    useEffect(() => {
+        const dialog = dialogRef.current
+        if (!dialog) { return }
+        const handleCancel = (e: Event) => { e.preventDefault(); closeHelp() }
+        dialog.addEventListener('cancel', handleCancel)
+        return () => { dialog.removeEventListener('cancel', handleCancel) }
+    }, [closeHelp])
+
+    // Move focus to heading when response changes so focus doesn't fall to dialog root
     useEffect(() => {
         if (!isOpen || !response) { return }
-        if (response.status === 'ok') {
-            const topic = response.topic
-            const parts: string[] = [topic.brief]
-            if (topic.syntax.length > 0) { parts.push('Syntax: ' + topic.syntax.join(', ')) }
-            if (topic.seeAlso.length > 0) { parts.push('See also: ' + topic.seeAlso.join(', ')) }
-            useAnnounceStore.getState().pushMessage(stripMarkup(parts.join('. ')), 'assertive')
-        } else if (response.status === 'multiple') {
-            const titles = response.matches.map((m) => m.title).join(', ')
-            const label = response.term ? `Multiple matches for "${response.term}": ${titles}` : `Help categories: ${titles}`
-            useAnnounceStore.getState().pushMessage(label, 'assertive')
-        }
+        headingRef.current?.focus()
     }, [isOpen, response])
-
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            if (e.key === 'Escape' && isOpen) { closeHelp() }
-        }
-        document.addEventListener('keydown', handler)
-        return () => { document.removeEventListener('keydown', handler) }
-    }, [isOpen, closeHelp])
 
     return (
         <dialog
             ref={dialogRef}
+            aria-labelledby="help-modal-title"
             className="fixed z-50 m-auto max-w-2xl w-full max-h-[80vh] rounded-lg bg-gray-900 text-gray-100 shadow-2xl p-0 backdrop:bg-black/60 border border-gray-700"
             onClick={(e) => { if (e.target === dialogRef.current) { closeHelp() } }}
         >
             {response && (
-                <div className="flex flex-col max-h-[80vh]">
-                    <header className="flex items-center justify-between px-4 py-3 border-b border-gray-700 shrink-0">
-                        <h2 className="text-lg font-semibold">
+                <div className="relative flex flex-col max-h-[80vh]">
+                    <div className="px-4 py-3 border-b border-gray-700 shrink-0 pr-12">
+                        <h2 id="help-modal-title" ref={headingRef} tabIndex={-1} className="text-lg font-semibold outline-none">
                             {response.status === 'ok'
                                 ? response.topic.title
                                 : response.status === 'multiple'
@@ -64,14 +57,12 @@ export function HelpModal() {
                                         ? `Help: "${response.term}"`
                                         : ''}
                         </h2>
-                        <button
-                            onClick={closeHelp}
-                            className="text-gray-400 hover:text-gray-100 text-xl leading-none ml-4"
-                            aria-label="Close help"
-                        >
-                            &times;
-                        </button>
-                    </header>
+                    </div>
+                    {inDialogAnnouncement && (
+                        <div key={inDialogKey} role="alert" aria-live="assertive" aria-atomic="true" className="sr-only">
+                            {inDialogAnnouncement}
+                        </div>
+                    )}
                     <div className="overflow-y-auto px-4 py-4 flex-1">
                         {response.status === 'ok' && <HelpTopicContent topic={response.topic} />}
                         {response.status === 'multiple' && (
@@ -81,6 +72,18 @@ export function HelpModal() {
                             <p className="text-gray-400 text-sm">No help topic found for "{response.term}".</p>
                         )}
                     </div>
+                    <div className="sr-only">
+                        {response.status === 'ok'
+                            ? 'Press Alt+H to read detailed help text. Press Escape to exit.'
+                            : 'Press Escape to exit.'}
+                    </div>
+                    <button
+                        onClick={closeHelp}
+                        className="absolute top-3 right-4 text-gray-400 hover:text-gray-100 text-xl leading-none"
+                        aria-label="Close help"
+                    >
+                        &times;
+                    </button>
                 </div>
             )}
         </dialog>
@@ -105,7 +108,7 @@ function HelpTopicContent({ topic }: { topic: HelpTopicData }) {
                 </div>
             )}
 
-            <div className="text-sm leading-relaxed whitespace-pre-wrap">
+            <div aria-hidden="true" className="text-sm leading-relaxed whitespace-pre-wrap">
                 <ColorTaggedText text={topic.body} />
             </div>
 
@@ -133,7 +136,7 @@ function HelpDisambiguation({ term, matches }: { term: string; matches: HelpTopi
     return (
         <div className="space-y-2">
             <p className="text-gray-400 text-sm">
-                {term ? `Multiple topics match "${term}":` : 'Browse a category or type help [topic]:'}
+                {term ? `Multiple topics match "${term}":` : 'Select a category:'}
             </p>
             <ul className="space-y-1">
                 {matches.map((m) => (
@@ -142,8 +145,10 @@ function HelpDisambiguation({ term, matches }: { term: string; matches: HelpTopi
                             className="text-left w-full hover:bg-gray-800 rounded px-2 py-1.5 flex gap-3"
                             onClick={() => { sendCommand(`help ${m.id}`) }}
                         >
-                            <span className="text-blue-400 font-mono shrink-0">{m.id}</span>
-                            <span className="text-gray-300">{m.title}</span>
+                            {m.id !== m.title.toLowerCase()
+                                ? <><span className="text-blue-400 font-mono shrink-0">{m.id}</span><span className="text-gray-300">{m.title}</span></>
+                                : <span className="text-blue-400 font-mono">{m.title}</span>
+                            }
                         </button>
                     </li>
                 ))}

--- a/client/src/stores/commandBarStore.ts
+++ b/client/src/stores/commandBarStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { useHelpStore } from './helpStore'
 
 interface CommandBarState {
   pending: string
@@ -13,5 +14,8 @@ export const useCommandBarStore = create<CommandBarState>()((set) => ({
   focusToken: 0,
   setPending: (cmd) => set({ pending: cmd }),
   clearPending: () => set({ pending: '' }),
-  requestFocus: () => set((s) => ({ focusToken: s.focusToken + 1 })),
+  requestFocus: () => {
+    if (useHelpStore.getState().isOpen) { return }
+    set((s) => ({ focusToken: s.focusToken + 1 }))
+  },
 }))

--- a/client/src/stores/helpStore.ts
+++ b/client/src/stores/helpStore.ts
@@ -24,13 +24,41 @@ export type HelpResponse =
 interface HelpState {
     isOpen: boolean
     response: HelpResponse | null
+    dialogKey: number
+    inDialogKey: number
+    inDialogAnnouncement: string
     openHelp: (response: HelpResponse) => void
     closeHelp: () => void
+    pushAnnouncement: (text: string) => void
 }
+
+let announcementTimer: ReturnType<typeof setTimeout> | null = null
 
 export const useHelpStore = create<HelpState>()((set) => ({
     isOpen: false,
     response: null,
-    openHelp: (response) => { set({ isOpen: true, response }) },
-    closeHelp: () => { set({ isOpen: false }) },
+    dialogKey: 0,
+    inDialogKey: 0,
+    inDialogAnnouncement: '',
+    openHelp: (response) => {
+        if (announcementTimer) { clearTimeout(announcementTimer) }
+        set((state) => ({
+            isOpen: true,
+            response,
+            dialogKey: state.dialogKey + 1,
+            inDialogAnnouncement: '',
+        }))
+    },
+    closeHelp: () => {
+        if (announcementTimer) { clearTimeout(announcementTimer) }
+        set({ isOpen: false, inDialogAnnouncement: '' })
+    },
+    pushAnnouncement: (text) => {
+        if (announcementTimer) { clearTimeout(announcementTimer) }
+        set((state) => ({ inDialogKey: state.inDialogKey + 1, inDialogAnnouncement: text }))
+        announcementTimer = setTimeout(() => {
+            set({ inDialogAnnouncement: '' })
+            announcementTimer = null
+        }, 1000)
+    },
 }))

--- a/packs/example-pack/help/classes.yaml
+++ b/packs/example-pack/help/classes.yaml
@@ -7,3 +7,4 @@ body: |
   Your class determines your starting skill and spell tree
 
   Type help [class name] for details on a specific class.
+see_also: [creation, warrior, mage, races]

--- a/packs/example-pack/help/combat-basics.yaml
+++ b/packs/example-pack/help/combat-basics.yaml
@@ -14,4 +14,4 @@ body: |
   Before engaging, use consider to gauge how dangerous a target
   is relative to your level. If things go badly, flee will
   attempt to escape combat.
-see_also: [combat]
+see_also: [combat, consider, flee, wimpy, rescue]

--- a/packs/example-pack/help/combat.yaml
+++ b/packs/example-pack/help/combat.yaml
@@ -9,4 +9,4 @@ body: |
 
   See the related topics below for details on specific aspects
   of the combat system.
-see_also: [combat-basics]
+see_also: [combat-basics, kill, flee, wimpy, consider, rescue]

--- a/packs/example-pack/help/creation.yaml
+++ b/packs/example-pack/help/creation.yaml
@@ -1,0 +1,20 @@
+id: "creation"
+title: "Character Creation"
+category: "creation"
+keywords: [create, new character, start, begin, chargen, race, class]
+brief: "Overview of races and classes available during character creation."
+body: |
+  When creating a new character you will choose a race and a class.
+  Each combination produces a different play style, stat caps, and
+  ability set.
+
+  RACES: Determines your base stat caps, natural modifiers, and some
+  passive traits. Available races: Human, Elf.
+
+  CLASSES: Determines your HP and resource growth, what abilities you
+  learn as you level, and your role in a group. Available classes:
+  Warrior, Mage.
+
+  Read the individual help topics for each race and class before
+  making your choice. The combination matters more than either alone.
+see_also: [races, classes, human, elf, warrior, mage, character-creation]

--- a/packs/example-pack/help/elf.yaml
+++ b/packs/example-pack/help/elf.yaml
@@ -1,0 +1,23 @@
+id: "elf"
+title: "Elf"
+category: "creation"
+keywords: [race, graceful, magic, arcane, nimble, perceptive, long-lived]
+brief: "Graceful and attuned to magic - gifted in arcane arts and agility."
+body: |
+  Elves are long-lived and naturally gifted in the arcane arts.
+  They are nimble, perceptive, and dangerous casters, though less
+  physically hardy than humans.
+
+  STAT CAPS: Strength 22, Intelligence 28, Wisdom 27, Dexterity 28,
+  Constitution 20, Luck 25.
+
+  POOL CAPS: HP 16, Resource 22, Move 18.
+
+  SPELLCASTING: Elves have excellent mana efficiency, reducing spell
+  costs by 15%. Their high intelligence and wisdom caps make them
+  outstanding mages.
+
+  Elves are the strongest choice for Mage. Their lower constitution
+  and HP cap make the Warrior path harder but not impossible for
+  players who prefer a challenge.
+see_also: [human, races, creation, mage, warrior]

--- a/packs/example-pack/help/hello.yaml
+++ b/packs/example-pack/help/hello.yaml
@@ -1,0 +1,16 @@
+id: "hello"
+title: "Hello"
+category: "world"
+role: "player"
+keywords: [hi, greet, greeting, example]
+brief: "Greet the world."
+syntax:
+  - "hello"
+  - "hi"
+body: |
+  Hello (or hi) sends a greeting to the world. It is a simple example
+  command included with the example pack to demonstrate how commands
+  work in Tapestry.
+
+  Use it to say hello when you first log in. Everyone will see it.
+see_also: [say, emote, world]

--- a/packs/example-pack/help/human.yaml
+++ b/packs/example-pack/help/human.yaml
@@ -1,0 +1,22 @@
+id: "human"
+title: "Human"
+category: "creation"
+keywords: [race, versatile, adaptable, common, folk, balanced]
+brief: "Adaptable and ambitious - the most common folk in the world."
+body: |
+  Humans are the most widespread race, known for their adaptability
+  and drive. They excel at no single discipline but take to any path
+  with ease, making them a reliable choice for any class.
+
+  STAT CAPS: Strength 25, Intelligence 25, Wisdom 25, Dexterity 25,
+  Constitution 25, Luck 25.
+
+  POOL CAPS: HP 18, Resource 18, Move 16.
+
+  SPELLCASTING: Humans have a slight advantage in mana efficiency,
+  reducing spell costs by 10%.
+
+  Humans pair well with any class. Their balanced caps mean no class
+  is a poor fit, though they lack the specialized highs that other
+  races bring to their preferred disciplines.
+see_also: [elf, races, creation, warrior, mage]

--- a/packs/example-pack/help/mage.yaml
+++ b/packs/example-pack/help/mage.yaml
@@ -1,0 +1,24 @@
+id: "mage"
+title: "Mage"
+category: "creation"
+keywords: [class, wizard, arcane, magic, caster, spellcaster, intelligence]
+brief: "Student of arcane forces - raw magical power, healing, and broad spell coverage."
+body: |
+  Mages wield raw magical power. They can heal allies, destroy enemies,
+  and bring a broad and flexible spell list to any group. Their HP is
+  fragile, but their resource growth and spell access more than compensate.
+
+  HP GROWTH: 1d6 per level. Resource: 2d4+1 per level. Trains per level: 5.
+
+  ABILITIES BY LEVEL:
+    1  - cure_light
+    3  - fireball
+    5  - shield
+    10 - blindness
+    15 - poison
+    20 - second_cast
+
+  Mages rely on intelligence and wisdom. Elves are the ideal Mage race
+  due to high int/wis caps and superior mana efficiency. second_cast at
+  level 20 allows two spells per round, making late-game Mages dominant.
+see_also: [warrior, classes, creation, human, elf]

--- a/packs/example-pack/help/races.yaml
+++ b/packs/example-pack/help/races.yaml
@@ -8,3 +8,4 @@ body: |
   access to racial abilities as you level.
 
   Type help [race name] for details on a specific race.
+see_also: [creation, human, elf, classes]

--- a/packs/example-pack/help/warrior.yaml
+++ b/packs/example-pack/help/warrior.yaml
@@ -1,0 +1,25 @@
+id: "warrior"
+title: "Warrior"
+category: "creation"
+keywords: [class, fighter, melee, tank, physical, arms, armor, frontline]
+brief: "Master of arms and armor - front-line fighters built for steel and strength."
+body: |
+  Warriors are the front-line combatants of the world. They absorb
+  punishment and dish it back with a deep skill tree and strong HP
+  growth. Every group wants a Warrior in the thick of it.
+
+  HP GROWTH: 2d6+2 per level. Move: 1d4 per level. Trains per level: 5.
+
+  ABILITIES BY LEVEL:
+    1  - dodge
+    3  - kick
+    5  - parry
+    8  - battle_stance
+    12 - bash
+    18 - second_attack
+    25 - enhanced_damage
+
+  Warriors rely on strength, constitution, and dexterity. Focus trains
+  on strength and constitution early to maximize survivability and damage.
+  second_attack at level 18 dramatically increases damage output.
+see_also: [mage, classes, creation, human, elf]

--- a/packs/tapestry-core/help/accessibility.yaml
+++ b/packs/tapestry-core/help/accessibility.yaml
@@ -1,0 +1,29 @@
+id: "accessibility"
+title: "Accessibility"
+category: "accessibility"
+role: "player"
+keywords: [screen reader, blind, vi, accessible, keyboard, shortcut, aria]
+brief: "Accessibility features for screen reader and keyboard users."
+body: |
+  The Tapestry web client includes features designed specifically for
+  screen reader users, blind players, and anyone who prefers keyboard
+  navigation over a mouse.
+
+  KEYBOARD SHORTCUTS: Several Alt-key shortcuts give quick access to
+  important information without navigating the page manually.
+
+  SCREEN READER SUPPORT: Room descriptions, combat events, and key
+  game events are announced through ARIA live regions so screen readers
+  pick them up automatically as they happen.
+
+  STRUCTURED DATA: The server sends structured game data (GMCP) that
+  the client uses to present information in screen-reader-friendly
+  panels, rather than relying on raw scrolling text alone.
+
+  MODALS: Help topics, inventory, and other panels open as accessible
+  modals that trap focus, support Escape to close, and return focus to
+  your previous position when dismissed.
+
+  See the related topics below for specifics on keyboard shortcuts,
+  screen reader behavior, and GMCP structured data.
+see_also: [keyboard-shortcuts, screen-reader, gmcp-overview]

--- a/packs/tapestry-core/help/admin.yaml
+++ b/packs/tapestry-core/help/admin.yaml
@@ -1,0 +1,24 @@
+id: "admin"
+title: "Admin Commands"
+category: "admin"
+role: "admin"
+keywords: [immortal, god, wizard, admin, staff, imm]
+brief: "Administrative commands for managing the game world and players."
+body: |
+  Admin commands give elevated access to game internals. They are
+  only available to players with admin-level role access.
+
+  PLAYER MANAGEMENT: Use inspect to view full details on any target.
+  Use set to modify player, NPC, or item fields directly. Use grant
+  to award experience or trains, and forget/learn to remove or add
+  abilities.
+
+  WORLD MANAGEMENT: spawn creates a mob from a template in your room.
+  loaditem adds an item from a template to your inventory. purge removes
+  NPCs, items, or all entities from the current room. teleport moves
+  yourself or another player to a room or player.
+
+  CLASS TOOLS: setclass assigns a class to a player and grants their
+  level-1 abilities. settrainable is a debug tool for toggling stats
+  in and out of the trainable list.
+see_also: [forget, grant, inspect, learn, loaditem, purge, set, setclass, settrainable, spawn, teleport]

--- a/packs/tapestry-core/help/affects.yaml
+++ b/packs/tapestry-core/help/affects.yaml
@@ -1,0 +1,20 @@
+id: "affects"
+title: "Affects"
+category: "character"
+role: "player"
+keywords: [aff, buffs, debuffs, effects, active, spells on, conditions]
+brief: "Show active effects currently on your character."
+syntax:
+  - "affects"
+  - "aff"
+body: |
+  Affects lists every spell or condition currently active on you,
+  including what stat it modifies, how much, and how long it lasts.
+
+  Positive effects (buffs) can come from spells cast by yourself or
+  allies, potions, scrolls, or special room effects. Negative effects
+  (debuffs) can come from enemy spells or environmental hazards.
+
+  Effects expire naturally when their duration runs out. Some can be
+  removed early with dispel or remove curse spells.
+see_also: [score, cast, character]

--- a/packs/tapestry-core/help/builder.yaml
+++ b/packs/tapestry-core/help/builder.yaml
@@ -1,0 +1,21 @@
+id: "builder"
+title: "Builder Commands"
+category: "builder"
+role: "builder"
+keywords: [build, zone, area, room, link, connect, create]
+brief: "Builder commands for creating and connecting rooms."
+body: |
+  Builder commands are available to players with builder-level access.
+  They are used to construct and connect the game world.
+
+  CONNECTIONS: Use connections to view the exits and links defined for
+  the current room, or to list connections across all rooms.
+
+  LINKING ROOMS: Use link to create a connection between two rooms.
+  The link command walks you through a guided flow to specify the
+  source room, direction, and destination. Rooms can be linked across
+  different content packs.
+
+  REMOVING LINKS: Use unlink to remove an exit connection from the
+  current room. This does not remove the destination room itself.
+see_also: [connections, link, unlink]

--- a/packs/tapestry-core/help/buy.yaml
+++ b/packs/tapestry-core/help/buy.yaml
@@ -1,0 +1,18 @@
+id: "buy"
+title: "Buy"
+category: "shop"
+role: "player"
+keywords: [purchase, shop, merchant, acquire, get, gold]
+brief: "Buy an item from a shop."
+syntax:
+  - "buy [item]"
+body: |
+  Buy purchases the named item from the merchant in your current room
+  and adds it to your inventory. The cost is deducted from your gold.
+
+  If you cannot afford the item or do not have enough carry capacity,
+  the purchase fails. Use list to see prices before buying.
+
+  Item names can be partial matches. If there are multiple matching
+  items, the first one in the shop's list is selected.
+see_also: [list, sell, value, shop]

--- a/packs/tapestry-core/help/cast.yaml
+++ b/packs/tapestry-core/help/cast.yaml
@@ -1,0 +1,21 @@
+id: "cast"
+title: "Cast"
+category: "character"
+role: "player"
+keywords: [spell, magic, invoke, mana, resource]
+brief: "Cast a spell from your learned spell list."
+syntax:
+  - "cast '[spell name]'"
+  - "cast '[spell name]' [target]"
+body: |
+  Cast invokes a spell by name. The spell name must be in quotes if
+  it is more than one word. A target is required for spells that
+  affect a specific entity.
+
+  Casting costs resource (mana). If you do not have enough, the cast
+  fails. Your proficiency in the spell affects success rate and
+  effect strength.
+
+  Some spells can be cast during combat. Others are non-combat only.
+  Check the spell description with examine or the spells list.
+see_also: [spells, quaff, recite, character]

--- a/packs/tapestry-core/help/character-creation.yaml
+++ b/packs/tapestry-core/help/character-creation.yaml
@@ -1,0 +1,22 @@
+id: "character-creation"
+title: "Character Creation"
+category: "creation"
+keywords: [create, new, race, class, start, begin, chargen]
+brief: "Overview of the character creation process."
+body: |
+  Creating a character in Tapestry involves choosing a name, a race,
+  and a class. Each choice shapes how your character develops and
+  plays throughout the game.
+
+  RACE: Your race determines your base stat caps, natural abilities,
+  and some passive modifiers. Choose a race that fits the kind of
+  character you want to play.
+
+  CLASS: Your class determines how you fight, what abilities you learn
+  as you level up, and how fast your HP and resources grow. Each class
+  has a distinct role in groups.
+
+  Once created, your character enters the world at the starting area.
+  You can use the help system at any time to learn more about commands,
+  your class, and the world around you.
+see_also: [races, classes]

--- a/packs/tapestry-core/help/character.yaml
+++ b/packs/tapestry-core/help/character.yaml
@@ -1,0 +1,23 @@
+id: "character"
+title: "Character"
+category: "character"
+role: "player"
+keywords: [stats, status, info, sheet, profile, attributes]
+brief: "View and understand your character's stats, effects, and abilities."
+body: |
+  Your character has a set of stats, active effects, and learned abilities
+  that define how you interact with the world.
+
+  STATS: Use score to see your full character sheet - HP, resource, move,
+  attributes, level, experience, and more.
+
+  EFFECTS: Use affects (or aff) to see what spells or conditions are
+  currently active on your character, and how long they last.
+
+  ABILITIES: Use skills and spells to see what you have learned.
+  Use tree to see your class path and which abilities are available
+  at each level.
+
+  MAGIC: Cast spells with cast. Use quaff to drink a potion and recite
+  to use a scroll. Effects vary by item.
+see_also: [score, affects, skills, spells, tree, cast, quaff, recite, progression]

--- a/packs/tapestry-core/help/clan.yaml
+++ b/packs/tapestry-core/help/clan.yaml
@@ -1,0 +1,18 @@
+id: "clan"
+title: "Clan"
+category: "communication"
+role: "player"
+keywords: [guild, organization, clan channel, members]
+brief: "Send a message to your clan members."
+syntax:
+  - "clan [message]"
+body: |
+  Clan sends a message to all online members of your clan, regardless
+  of where they are in the world. Only clan members can see it.
+
+  You must belong to a clan to use this command. If you are not in a
+  clan, the command will tell you so.
+
+  Clan chat is useful for coordinating with your organization without
+  broadcasting to the whole server via gossip.
+see_also: [gossip, tell, communication]

--- a/packs/tapestry-core/help/close.yaml
+++ b/packs/tapestry-core/help/close.yaml
@@ -1,0 +1,18 @@
+id: "close"
+title: "Close"
+category: "navigation"
+role: "player"
+keywords: [door, shut, container]
+brief: "Close a door or container."
+syntax:
+  - "close [direction]"
+  - "close [container]"
+body: |
+  Close shuts an open door in the given direction or closes an open
+  container. A closed door blocks movement until opened again.
+
+  Closing a door does not lock it. Use the lock command after closing
+  if you want to prevent others from opening it.
+
+  Containers must be closed before they can be locked.
+see_also: [open, lock, unlock, navigation]

--- a/packs/tapestry-core/help/combat.yaml
+++ b/packs/tapestry-core/help/combat.yaml
@@ -1,0 +1,25 @@
+id: "combat"
+title: "Combat"
+category: "combat"
+role: "player"
+keywords: [fight, attack, battle, kill, enemy, mob]
+brief: "How combat works in Tapestry."
+body: |
+  Combat in Tapestry is round-based. When you attack a target with kill
+  (or attack), you and your enemy exchange blows each round until one
+  side flees or falls.
+
+  INITIATING: Use kill [target] to begin combat. Use consider (or con)
+  first to gauge how dangerous a target is before committing.
+
+  DURING COMBAT: Your attacks happen automatically each round. Some
+  abilities and spells can be used mid-combat for extra effects.
+  Use rescue to pull an enemy off an ally who is in trouble.
+
+  ESCAPING: flee attempts to run from the fight. Set wimpy to a HP
+  threshold and you will automatically attempt to flee when HP drops
+  that low.
+
+  When you die, you will lose some experience and your corpse will
+  remain in the room with your items.
+see_also: [kill, flee, wimpy, consider, rescue, combat-basics]

--- a/packs/tapestry-core/help/commands.yaml
+++ b/packs/tapestry-core/help/commands.yaml
@@ -1,0 +1,19 @@
+id: "commands"
+title: "Commands"
+category: "world"
+role: "player"
+keywords: [cmds, list, available, what can i do, command list]
+brief: "List all commands currently available to you."
+syntax:
+  - "commands"
+  - "cmds"
+body: |
+  Commands (or cmds) prints a complete list of every command available
+  to your character given your current role and location.
+
+  The list reflects your actual access level. Admin and builder commands
+  appear only for those with appropriate roles.
+
+  Use help [command] to get detailed information about any specific
+  command from the list.
+see_also: [help, world]

--- a/packs/tapestry-core/help/communication.yaml
+++ b/packs/tapestry-core/help/communication.yaml
@@ -1,0 +1,22 @@
+id: "communication"
+title: "Communication"
+category: "communication"
+role: "player"
+keywords: [talk, chat, message, channel, speak]
+brief: "How to communicate with other players and the world."
+body: |
+  Tapestry has several channels for communicating with other players.
+  Each channel has a different audience and purpose.
+
+  LOCAL: say (or ') speaks to everyone in your room. emote (or :)
+  lets you describe an action to the room.
+
+  PRIVATE: tell sends a private message to a specific player anywhere
+  in the world. reply responds to the last tell you received.
+
+  GLOBAL: gossip reaches all players. yell reaches everyone in the
+  same area. clan reaches members of your clan.
+
+  ADMIN: immtalk is the immortal channel, visible only to admin-level
+  players. Use ; as an alias.
+see_also: [say, tell, reply, gossip, yell, clan, emote, immtalk]

--- a/packs/tapestry-core/help/connections.yaml
+++ b/packs/tapestry-core/help/connections.yaml
@@ -1,0 +1,18 @@
+id: "connections"
+title: "Connections"
+category: "builder"
+role: "builder"
+keywords: [exits, links, rooms, map, builder, connected]
+brief: "List connections for this room or all rooms."
+syntax:
+  - "connections"
+  - "connections all"
+body: |
+  Connections lists all defined exits and links for the current room,
+  including direction, target room ID, and any flags (locked, hidden,
+  one-way).
+
+  Use "connections all" to list every connection across all rooms
+  in the loaded packs. Useful for finding broken or missing links
+  during world building.
+see_also: [link, unlink, builder]

--- a/packs/tapestry-core/help/consider.yaml
+++ b/packs/tapestry-core/help/consider.yaml
@@ -1,0 +1,21 @@
+id: "consider"
+title: "Consider"
+category: "combat"
+role: "player"
+keywords: [con, assess, evaluate, size up, dangerous, compare]
+brief: "Assess how dangerous a target is compared to you."
+syntax:
+  - "consider [target]"
+  - "con [target]"
+body: |
+  Consider gives you a rough assessment of how a target compares to
+  your current level and combat ability. It uses plain language:
+  "easy prey," "a fair fight," "you would need a lot of luck," and so on.
+
+  Always consider before initiating combat, especially in new areas.
+  A target that looks manageable may have special abilities or high
+  HP that make it much harder than the level suggests.
+
+  Consider does not guarantee outcomes - it is an estimate, not a
+  guarantee.
+see_also: [kill, flee, combat]

--- a/packs/tapestry-core/help/drink.yaml
+++ b/packs/tapestry-core/help/drink.yaml
@@ -1,0 +1,19 @@
+id: "drink"
+title: "Drink"
+category: "inventory"
+role: "player"
+keywords: [quaff, sip, water, potion, flask, liquid, thirst]
+brief: "Drink from an item in your inventory."
+syntax:
+  - "drink [item]"
+body: |
+  Drink consumes liquid from a container in your inventory, such as
+  a water flask or a liquid-filled vial. The effect depends on what
+  the container holds.
+
+  Water and common drinks satisfy thirst if the server tracks it.
+  Special liquids may heal, harm, or apply effects.
+
+  To drink from a fountain or well in the room directly, you may
+  need to fill a container first with the fill command.
+see_also: [fill, eat, quaff, inventory]

--- a/packs/tapestry-core/help/drop.yaml
+++ b/packs/tapestry-core/help/drop.yaml
@@ -1,0 +1,20 @@
+id: "drop"
+title: "Drop"
+category: "inventory"
+role: "player"
+keywords: [discard, leave, put down, throw down]
+brief: "Drop an item from your inventory onto the ground."
+syntax:
+  - "drop [item]"
+  - "drop all"
+body: |
+  Drop removes an item from your inventory and places it on the ground
+  in your current room. Other players can then pick it up.
+
+  Items dropped in the world may decay over time and disappear.
+  Do not drop items you want to keep unless you plan to retrieve them
+  quickly.
+
+  Use "drop all" to drop everything you are carrying at once. Be careful
+  with this - it drops equipped items too if you are not careful.
+see_also: [get, put, give, inventory]

--- a/packs/tapestry-core/help/eat.yaml
+++ b/packs/tapestry-core/help/eat.yaml
@@ -1,0 +1,19 @@
+id: "eat"
+title: "Eat"
+category: "inventory"
+role: "player"
+keywords: [food, consume, hunger, meal]
+brief: "Eat food from your inventory."
+syntax:
+  - "eat [food]"
+body: |
+  Eat consumes a food item from your inventory. Some food items restore
+  HP or other stats when eaten. Others simply satisfy hunger if the
+  server tracks that.
+
+  You must have the food in your inventory to eat it. Food items are
+  consumed on use.
+
+  Some magic items can also be eaten for special effects - examine
+  them first if you are unsure what they do.
+see_also: [drink, inventory]

--- a/packs/tapestry-core/help/emote.yaml
+++ b/packs/tapestry-core/help/emote.yaml
@@ -2,7 +2,7 @@ id: "emote"
 title: "Emote"
 category: "communication"
 role: "player"
-keywords: [action, roleplay, rp, pose, :, me]
+keywords: [action, roleplay, rp, pose, me]
 brief: "Perform a freeform emote action visible to the room."
 syntax:
   - "emote [action]"

--- a/packs/tapestry-core/help/emote.yaml
+++ b/packs/tapestry-core/help/emote.yaml
@@ -1,0 +1,19 @@
+id: "emote"
+title: "Emote"
+category: "communication"
+role: "player"
+keywords: [action, roleplay, rp, pose, :, me]
+brief: "Perform a freeform emote action visible to the room."
+syntax:
+  - "emote [action]"
+  - ": [action]"
+body: |
+  Emote lets you describe a custom action that the room can see.
+  Your name is prepended automatically.
+
+  Example: "emote stretches and yawns." becomes "Travis stretches and yawns."
+
+  Use the colon (:) as a shortcut. Emote is freeform - you can write
+  anything. For pre-written gestures with targeted versions, see the
+  social command list.
+see_also: [social, say, communication]

--- a/packs/tapestry-core/help/enter.yaml
+++ b/packs/tapestry-core/help/enter.yaml
@@ -1,0 +1,19 @@
+id: "enter"
+title: "Enter"
+category: "navigation"
+role: "player"
+keywords: [portal, gateway, passage, go in, go through]
+brief: "Enter a portal or special exit."
+syntax:
+  - "enter [portal]"
+body: |
+  Some exits in the world are portals or special passages that do not
+  correspond to a standard direction. Use enter to pass through them.
+
+  You may need to name the portal specifically if there is more than
+  one in the room. The room description will usually indicate what
+  can be entered.
+
+  To exit a portal destination, use leave or a standard directional
+  command if one is available.
+see_also: [leave, navigation]

--- a/packs/tapestry-core/help/equipment.yaml
+++ b/packs/tapestry-core/help/equipment.yaml
@@ -1,0 +1,24 @@
+id: "equipment"
+title: "Equipment"
+category: "equipment"
+role: "player"
+keywords: [eq, worn, wear, wield, armor, weapon, slot, gear]
+brief: "View and manage your equipped items."
+syntax:
+  - "equipment"
+  - "eq"
+body: |
+  Equipment shows all items you currently have worn or wielded. Each
+  item occupies a specific slot on your body: head, body, hands, legs,
+  feet, finger, neck, wrist, and so on.
+
+  WEARING ITEMS: Use wear [item] to equip an item from your inventory.
+  Tapestry will automatically find the right slot for most items.
+  Use wield [item] to equip a weapon in your main hand.
+
+  REMOVING ITEMS: Use remove [item] to take off a worn or wielded item
+  and return it to your inventory.
+
+  Better equipment improves your stats, armor class, and combat
+  effectiveness. Some items have level or stat requirements.
+see_also: [wear, wield, remove, inventory]

--- a/packs/tapestry-core/help/examine.yaml
+++ b/packs/tapestry-core/help/examine.yaml
@@ -1,0 +1,21 @@
+id: "examine"
+title: "Examine"
+category: "navigation"
+role: "player"
+keywords: [ex, exa, inspect, detail, study, look at]
+brief: "Examine an item or entity in detail."
+syntax:
+  - "examine [target]"
+  - "ex [target]"
+  - "exa [target]"
+body: |
+  Examine gives a detailed description of an item or entity. For items,
+  this often includes stats, condition, flags, and any special properties.
+  For NPCs and players, it shows equipment and visible details.
+
+  Examine works on items in your inventory, items on the ground, items
+  in the room, NPCs, and other players.
+
+  Use look for a quick glance; use examine when you need full details
+  before equipping, selling, or interacting with something.
+see_also: [look, navigation]

--- a/packs/tapestry-core/help/exits.yaml
+++ b/packs/tapestry-core/help/exits.yaml
@@ -1,0 +1,19 @@
+id: "exits"
+title: "Exits"
+category: "navigation"
+role: "player"
+keywords: [exit, doors, directions, out, where, go]
+brief: "List available exits from the current room."
+syntax:
+  - "exits"
+body: |
+  Exits lists all available exits from your current room without
+  printing the full room description. Useful when you already know
+  the room but want a quick reminder of where you can go.
+
+  Each exit shows the direction and a brief label for the destination.
+  Exits marked with a door symbol may require opening before you can
+  pass through.
+
+  For the full room view including description and contents, use look.
+see_also: [look, movement, navigation]

--- a/packs/tapestry-core/help/fill.yaml
+++ b/packs/tapestry-core/help/fill.yaml
@@ -1,0 +1,18 @@
+id: "fill"
+title: "Fill"
+category: "inventory"
+role: "player"
+keywords: [water, flask, canteen, container, refill]
+brief: "Fill a container from a liquid source."
+syntax:
+  - "fill [container]"
+  - "fill [container] [source]"
+body: |
+  Fill takes a liquid container in your inventory and fills it from a
+  source in the room - a fountain, well, barrel, or similar.
+
+  If there is only one valid source in the room, you do not need to
+  specify it. If there are multiple, name the one you want.
+
+  A filled container can then be used with drink to consume the liquid.
+see_also: [drink, inventory]

--- a/packs/tapestry-core/help/flee.yaml
+++ b/packs/tapestry-core/help/flee.yaml
@@ -1,0 +1,19 @@
+id: "flee"
+title: "Flee"
+category: "combat"
+role: "player"
+keywords: [run, escape, retreat, get away, exit combat]
+brief: "Attempt to flee from combat."
+syntax:
+  - "flee"
+body: |
+  Flee attempts to escape from combat by running through a random
+  available exit. Success is not guaranteed - if you fail, you stay
+  in the fight and lose some experience.
+
+  When you flee successfully, combat ends and you land in an adjacent
+  room. The enemy does not follow automatically.
+
+  Set wimpy to automatically flee when your HP drops to a threshold,
+  so you do not have to manually flee when things go badly.
+see_also: [wimpy, kill, combat]

--- a/packs/tapestry-core/help/follow.yaml
+++ b/packs/tapestry-core/help/follow.yaml
@@ -1,0 +1,19 @@
+id: "follow"
+title: "Follow"
+category: "group"
+role: "player"
+keywords: [trail, shadow, tag along, auto move, join]
+brief: "Follow a player so you move with them automatically."
+syntax:
+  - "follow [player]"
+  - "follow stop"
+body: |
+  Follow makes you automatically move with the named player whenever
+  they change rooms. This is how groups move together efficiently.
+
+  Use "follow stop" to stop following and move independently again.
+  You can only follow one person at a time.
+
+  The person you follow must be in the same room to begin following.
+  If they have nofollow enabled, you cannot follow them.
+see_also: [nofollow, group, gtell]

--- a/packs/tapestry-core/help/forget.yaml
+++ b/packs/tapestry-core/help/forget.yaml
@@ -1,0 +1,17 @@
+id: "forget"
+title: "Forget"
+category: "admin"
+role: "admin"
+keywords: [remove ability, strip, unlearn, admin]
+brief: "Remove an ability from yourself or another player."
+syntax:
+  - "forget [ability]"
+  - "forget [player] [ability]"
+body: |
+  Forget removes a learned ability from a player's ability list.
+  Without a player name, it targets yourself. With a player name,
+  it targets that player.
+
+  Use with care - abilities removed this way must be re-granted with
+  learn or setclass. This is primarily a debug and correction tool.
+see_also: [learn, setclass, admin]

--- a/packs/tapestry-core/help/get.yaml
+++ b/packs/tapestry-core/help/get.yaml
@@ -1,0 +1,21 @@
+id: "get"
+title: "Get"
+category: "inventory"
+role: "player"
+keywords: [take, pick up, grab, loot, retrieve]
+brief: "Pick up an item from the room or a container."
+syntax:
+  - "get [item]"
+  - "get [item] [container]"
+  - "take [item]"
+  - "get all"
+body: |
+  Get picks up an item from the ground and adds it to your inventory.
+  Use "get all" to pick up everything in the room at once.
+
+  To retrieve an item from inside a container, specify the container
+  after the item name: "get sword pack" takes the sword from your pack.
+
+  You must have enough carry capacity to pick up the item. If you are
+  too encumbered, you will need to drop something first.
+see_also: [drop, put, inventory]

--- a/packs/tapestry-core/help/give.yaml
+++ b/packs/tapestry-core/help/give.yaml
@@ -1,0 +1,18 @@
+id: "give"
+title: "Give"
+category: "inventory"
+role: "player"
+keywords: [hand, transfer, trade, share]
+brief: "Give an item to another player or NPC."
+syntax:
+  - "give [item] [player]"
+body: |
+  Give transfers an item from your inventory to another player or NPC
+  in the same room. The target receives the item directly.
+
+  Both you and the target must be in the same room. You cannot give
+  items to players in other rooms - use drop if you need to leave
+  something for someone to pick up later.
+
+  Some NPCs accept items as part of quests or trade interactions.
+see_also: [drop, get, inventory]

--- a/packs/tapestry-core/help/gmcp-overview.yaml
+++ b/packs/tapestry-core/help/gmcp-overview.yaml
@@ -1,0 +1,26 @@
+id: "gmcp-overview"
+title: "GMCP Structured Data"
+category: "accessibility"
+role: "player"
+keywords: [gmcp, structured, data, protocol, client, response, json]
+brief: "How GMCP structured data enhances gameplay for all players, especially VI users."
+body: |
+  GMCP (Generic Mud Communication Protocol) lets the Tapestry server
+  send structured data alongside the normal text stream. The web client
+  uses this to build richer, more accessible interfaces.
+
+  Instead of parsing raw text, the client receives structured messages
+  for room state (Response.Room), help topics (Response.Help), inventory
+  contents (Response.Inventory), and other game events.
+
+  For VI and blind players, this means the client can present information
+  in organized, screen-reader-friendly panels rather than relying on the
+  player to parse scrolling text output. Room descriptions, item lists,
+  and help bodies are all available as structured content.
+
+  For all players, GMCP enables features like auto-updating status bars,
+  map displays, and context-aware command suggestions.
+
+  GMCP is handled automatically by the web client. No configuration is
+  required to benefit from it.
+see_also: [screen-reader, keyboard-shortcuts, accessibility]

--- a/packs/tapestry-core/help/gossip.yaml
+++ b/packs/tapestry-core/help/gossip.yaml
@@ -1,0 +1,18 @@
+id: "gossip"
+title: "Gossip"
+category: "communication"
+role: "player"
+keywords: [global, broadcast, all, world, chat, ooc]
+brief: "Send a message to all players currently online."
+syntax:
+  - "gossip [message]"
+body: |
+  Gossip sends your message to every player currently connected,
+  regardless of where they are in the world.
+
+  Use gossip for announcements, looking for groups, or general
+  conversation that does not need to be private or area-specific.
+
+  If the channel feels noisy, some servers offer a way to mute it -
+  check with an admin if you are unsure.
+see_also: [yell, tell, say, communication]

--- a/packs/tapestry-core/help/grant.yaml
+++ b/packs/tapestry-core/help/grant.yaml
@@ -1,0 +1,17 @@
+id: "grant"
+title: "Grant"
+category: "admin"
+role: "admin"
+keywords: [award, experience, xp, trains, admin]
+brief: "Award experience or trains to a player."
+syntax:
+  - "grant [player] exp [amount]"
+  - "grant [player] trains [amount]"
+body: |
+  Grant awards experience points or trains to the named player.
+  Useful for correcting progression loss, rewarding players, or
+  testing level-up behavior.
+
+  Granting enough experience may trigger a level-up. Trains are added
+  to the player's available train count.
+see_also: [set, admin]

--- a/packs/tapestry-core/help/group.yaml
+++ b/packs/tapestry-core/help/group.yaml
@@ -1,0 +1,33 @@
+id: "group"
+title: "Group"
+category: "group"
+role: "player"
+keywords: [party, team, follow, grouping, invite, members]
+brief: "Form and manage a group with other players."
+syntax:
+  - "group"
+  - "group invite [player]"
+  - "group accept"
+  - "group decline"
+  - "group leave"
+  - "group kick [player]"
+  - "group promote [player]"
+  - "group disband"
+body: |
+  Groups let players team up for adventuring. Experience and loot
+  from kills are shared among group members in the same room.
+
+  FORMING A GROUP: The group leader uses group invite [player] to
+  send an invitation. The invited player uses group accept or group
+  decline. The inviter must already be a group leader or solo.
+
+  GROUP CHAT: Use gtell (or gt) to send a message only your group
+  members can see, regardless of where they are in the world.
+
+  FOLLOWING: Use follow [player] to automatically move with someone
+  when they change rooms. Use follow stop to stop following. The
+  nofollow command toggles whether others can follow you.
+
+  MANAGEMENT: The group leader can kick members, promote a new leader,
+  or disband the group entirely. Any member can leave with group leave.
+see_also: [follow, nofollow, gtell]

--- a/packs/tapestry-core/help/gtell.yaml
+++ b/packs/tapestry-core/help/gtell.yaml
@@ -1,0 +1,19 @@
+id: "gtell"
+title: "Gtell"
+category: "group"
+role: "player"
+keywords: [gt, group tell, group chat, party chat]
+brief: "Send a message to your group members."
+syntax:
+  - "gtell [message]"
+  - "gt [message]"
+body: |
+  Gtell sends a message to every member of your group, regardless of
+  where they are in the world. Only group members can see it.
+
+  Use gt as a shortcut. Gtell is the primary coordination channel for
+  groups - use it for tactics, warnings, and general group chat.
+
+  You must be in a group to use gtell. If you are solo, the command
+  will tell you so.
+see_also: [group, follow, communication]

--- a/packs/tapestry-core/help/help.yaml
+++ b/packs/tapestry-core/help/help.yaml
@@ -1,0 +1,23 @@
+id: "help"
+title: "Help"
+category: "world"
+role: "player"
+keywords: [?, info, manual, documentation, guide, how to]
+brief: "Browse or search help topics."
+syntax:
+  - "help"
+  - "help [topic]"
+  - "? [topic]"
+body: |
+  Help with no argument opens the help index, listing available topic
+  categories. Help [topic] looks up a specific topic by name or keyword.
+
+  Topics are organized into categories: navigation, communication,
+  combat, inventory, equipment, progression, rest, shop, group, social,
+  world, character, and accessibility.
+
+  If you type a keyword that does not match a topic exactly, help will
+  search for related topics and suggest them.
+
+  Use ? as a shortcut for help.
+see_also: [commands, world]

--- a/packs/tapestry-core/help/immtalk.yaml
+++ b/packs/tapestry-core/help/immtalk.yaml
@@ -1,0 +1,17 @@
+id: "immtalk"
+title: "Immtalk"
+category: "communication"
+role: "admin"
+keywords: [immortal, admin channel, imm, ;, staff chat]
+brief: "Send a message on the immortal channel."
+syntax:
+  - "immtalk [message]"
+  - "; [message]"
+body: |
+  Immtalk sends a message on the immortal channel, visible only to
+  players with admin-level access. Use the semicolon (;) as a shortcut.
+
+  This channel is for admin coordination and is not visible to regular
+  players. Use it for world management discussion, player reports,
+  and staff communication.
+see_also: [communication, admin]

--- a/packs/tapestry-core/help/inspect.yaml
+++ b/packs/tapestry-core/help/inspect.yaml
@@ -1,0 +1,16 @@
+id: "inspect"
+title: "Inspect"
+category: "admin"
+role: "admin"
+keywords: [view, details, stats, debug, admin, examine deep]
+brief: "Show detailed stats, equipment, and properties for a target."
+syntax:
+  - "inspect [target]"
+body: |
+  Inspect gives a full detailed readout of a player, NPC, or item:
+  all stats, flags, equipment, active effects, template ID, and
+  other internal properties not visible through normal commands.
+
+  Use inspect when debugging unexpected behavior, verifying item
+  properties, or checking player state during support requests.
+see_also: [set, admin]

--- a/packs/tapestry-core/help/inventory.yaml
+++ b/packs/tapestry-core/help/inventory.yaml
@@ -1,0 +1,23 @@
+id: "inventory"
+title: "Inventory"
+category: "inventory"
+role: "player"
+keywords: [items, carry, bag, pack, belongings, i]
+brief: "View and manage the items you are carrying."
+syntax:
+  - "inventory"
+  - "i"
+body: |
+  Your inventory is the collection of items you are currently carrying.
+  Use inventory (or i) to see the full list.
+
+  Each item takes up carry weight. You can only carry so much before
+  you become encumbered, so manage your load carefully.
+
+  Items in your inventory can be equipped, eaten, drunk, read, used in
+  containers, given to others, or dropped on the ground.
+
+  CONTAINERS: Some items are containers - bags, packs, chests - that
+  hold other items. Use put and get to move items in and out of them.
+  Containers let you carry more by organizing your items.
+see_also: [get, drop, put, give, fill, eat, drink, equipment]

--- a/packs/tapestry-core/help/keyboard-shortcuts.yaml
+++ b/packs/tapestry-core/help/keyboard-shortcuts.yaml
@@ -1,0 +1,25 @@
+id: "keyboard-shortcuts"
+title: "Keyboard Shortcuts"
+category: "accessibility"
+role: "player"
+keywords: [alt, hotkey, shortcut, keybind, keyboard, quick access]
+brief: "Keyboard shortcuts for quick access to game information."
+body: |
+  The Tapestry web client provides Alt-key shortcuts that give fast
+  access to important information without navigating the page manually.
+  These are especially useful for screen reader users.
+
+  Alt+L: Re-announces the current room name and description through
+  your screen reader. Use this whenever you need to hear the room
+  context again after chat or combat scrolls it away.
+
+  Alt+C: Reads out context-sensitive commands available for your
+  current room or situation. Helpful for discovering what actions
+  are possible without leaving the input field.
+
+  Alt+H: Reads the full body text of the currently displayed help
+  topic aloud through your screen reader.
+
+  All interactive elements - help links, modal close buttons, and
+  navigation - are reachable with the Tab key. No mouse required.
+see_also: [screen-reader, gmcp-overview, accessibility]

--- a/packs/tapestry-core/help/kill.yaml
+++ b/packs/tapestry-core/help/kill.yaml
@@ -1,0 +1,21 @@
+id: "kill"
+title: "Kill"
+category: "combat"
+role: "player"
+keywords: [attack, fight, engage, murder, hit, k]
+brief: "Attack a target to initiate combat."
+syntax:
+  - "kill [target]"
+  - "attack [target]"
+body: |
+  Kill (or attack) initiates combat with the named target in your room.
+  Once started, combat continues automatically each round until one
+  side flees, dies, or is otherwise stopped.
+
+  Use consider first to gauge how dangerous a target is relative to
+  your level. Charging into a fight without assessing the risk is
+  how adventurers become corpses.
+
+  You can use abilities and spells during combat in addition to your
+  automatic attacks. Some spells have combat-only effects.
+see_also: [consider, flee, wimpy, combat]

--- a/packs/tapestry-core/help/learn.yaml
+++ b/packs/tapestry-core/help/learn.yaml
@@ -1,0 +1,17 @@
+id: "learn"
+title: "Learn"
+category: "admin"
+role: "admin"
+keywords: [grant ability, teach, add skill, spell, admin]
+brief: "Grant an ability to yourself or another player."
+syntax:
+  - "learn [ability]"
+  - "learn [player] [ability]"
+body: |
+  Learn grants a specific ability to a player. Without a player name,
+  it targets yourself. With a player name, it targets that player.
+
+  The ability must exist in a loaded content pack. Use this to manually
+  grant abilities outside of the normal class progression, or to correct
+  missing abilities after a setclass or pack change.
+see_also: [forget, setclass, admin]

--- a/packs/tapestry-core/help/leave.yaml
+++ b/packs/tapestry-core/help/leave.yaml
@@ -1,0 +1,19 @@
+id: "leave"
+title: "Leave"
+category: "navigation"
+role: "player"
+keywords: [exit portal, out, depart]
+brief: "Leave a portal or special exit."
+syntax:
+  - "leave"
+body: |
+  Leave is the counterpart to enter. Use it to exit a portal or
+  special area that you entered with the enter command.
+
+  In most cases, leave takes you back to where you came from, but
+  some portals are one-way. The room description will usually
+  indicate how to get out.
+
+  Standard directional commands may also work depending on the
+  exits available in the destination room.
+see_also: [enter, navigation]

--- a/packs/tapestry-core/help/link.yaml
+++ b/packs/tapestry-core/help/link.yaml
@@ -1,0 +1,20 @@
+id: "link"
+title: "Link"
+category: "builder"
+role: "builder"
+keywords: [connect, join, exit, room, builder, create exit]
+brief: "Link two rooms by creating an exit connection."
+syntax:
+  - "link"
+body: |
+  Link starts a guided flow to create a directional exit from the
+  current room to a destination room. You will be prompted for the
+  direction and target room ID.
+
+  Rooms can be linked across different content packs. The target room
+  must already exist. Link does not create rooms - it only connects
+  existing ones.
+
+  After linking, use connections to verify the new exit is correctly
+  configured.
+see_also: [unlink, connections, builder]

--- a/packs/tapestry-core/help/list.yaml
+++ b/packs/tapestry-core/help/list.yaml
@@ -1,0 +1,19 @@
+id: "list"
+title: "List"
+category: "shop"
+role: "player"
+keywords: [shop, browse, for sale, inventory, merchant, stock]
+brief: "List items for sale in a shop."
+syntax:
+  - "list"
+body: |
+  List shows every item currently available for purchase in the shop
+  you are in, along with their prices. You must be in a room with a
+  merchant NPC.
+
+  Prices are in gold. Your current gold is shown in score. Some shops
+  refresh their stock over time, so an empty slot today may be filled
+  later.
+
+  Use buy to purchase an item after finding it with list.
+see_also: [buy, sell, value, shop]

--- a/packs/tapestry-core/help/loaditem.yaml
+++ b/packs/tapestry-core/help/loaditem.yaml
@@ -1,0 +1,16 @@
+id: "loaditem"
+title: "Loaditem"
+category: "admin"
+role: "admin"
+keywords: [create item, spawn item, template, admin, add item]
+brief: "Add an item from a template ID to your inventory."
+syntax:
+  - "loaditem [template-id]"
+body: |
+  Loaditem creates an instance of an item from the given template ID
+  and places it directly in your inventory. Use it to test items,
+  restore lost items, or inspect item templates in play.
+
+  Template IDs are in the format "pack:item-id". Use inspect on an
+  existing item to find its template ID.
+see_also: [spawn, inspect, admin]

--- a/packs/tapestry-core/help/lock.yaml
+++ b/packs/tapestry-core/help/lock.yaml
@@ -1,0 +1,20 @@
+id: "lock"
+title: "Lock"
+category: "navigation"
+role: "player"
+keywords: [key, secure, door, container]
+brief: "Lock a door or container."
+syntax:
+  - "lock [direction]"
+  - "lock [container]"
+body: |
+  Lock secures a closed door or container so it cannot be opened
+  without the correct key. You must have the appropriate key in your
+  inventory to lock something.
+
+  The door or container must already be closed before you can lock it.
+  Use close first, then lock.
+
+  Locked doors prevent movement in that direction for anyone who does
+  not have the key.
+see_also: [unlock, close, open, navigation]

--- a/packs/tapestry-core/help/look.yaml
+++ b/packs/tapestry-core/help/look.yaml
@@ -1,0 +1,22 @@
+id: "look"
+title: "Look"
+category: "navigation"
+role: "player"
+keywords: [l, see, view, describe, room, description]
+brief: "Look at the room, an entity, or an item."
+syntax:
+  - "look"
+  - "look [target]"
+  - "l"
+  - "l [target]"
+body: |
+  Look with no argument displays the current room: its description,
+  visible exits, NPCs, and items on the ground.
+
+  Look at a specific target - an NPC, player, or item - to see a
+  brief description of that target. For more detail on items and
+  entities, use examine.
+
+  You receive a room look automatically when you move into a new room.
+  Use look to refresh it if the room state has changed.
+see_also: [examine, exits, navigation]

--- a/packs/tapestry-core/help/motd.yaml
+++ b/packs/tapestry-core/help/motd.yaml
@@ -1,0 +1,18 @@
+id: "motd"
+title: "Message of the Day"
+category: "world"
+role: "player"
+keywords: [message, announcement, news, bulletin, daily, login]
+brief: "Display the message of the day."
+syntax:
+  - "motd"
+body: |
+  Motd shows the current message of the day, which administrators use
+  to share news, announcements, events, and important changes.
+
+  The MOTD is shown automatically when you log in. Use motd to view
+  it again at any time during play.
+
+  Check the MOTD when you return after a break - it is the primary
+  way staff communicate updates to the player base.
+see_also: [packs, world]

--- a/packs/tapestry-core/help/movement.yaml
+++ b/packs/tapestry-core/help/movement.yaml
@@ -1,0 +1,26 @@
+id: "movement"
+title: "Movement"
+category: "navigation"
+role: "player"
+keywords: [north, south, east, west, up, down, n, s, e, w, u, d, walk, go, direction]
+brief: "Move between rooms using directional commands."
+syntax:
+  - "north | n"
+  - "south | s"
+  - "east  | e"
+  - "west  | w"
+  - "up    | u"
+  - "down  | d"
+body: |
+  Move in a direction to travel to the next room. Each move costs a
+  small amount of movement points. When movement runs out, you will
+  need to rest or sleep to recover before moving again.
+
+  Not all exits are available from every room. Use exits or look to
+  see which directions lead somewhere from your current position.
+
+  Some exits are blocked by closed doors. Use open [direction] to
+  open a door before passing through it.
+
+  Movement during combat is not allowed - use flee to escape a fight.
+see_also: [exits, look, open, flee, navigation]

--- a/packs/tapestry-core/help/navigation.yaml
+++ b/packs/tapestry-core/help/navigation.yaml
@@ -1,0 +1,22 @@
+id: "navigation"
+title: "Navigation"
+category: "navigation"
+role: "player"
+keywords: [move, movement, travel, direction, walk, go, room, exit]
+brief: "How to move through the world and interact with your surroundings."
+body: |
+  Navigation covers everything you need to explore the world: movement,
+  looking around, examining objects, and interacting with doors and portals.
+
+  MOVEMENT: Use the cardinal directions (north, south, east, west) and
+  vertical directions (up, down) to move between rooms. Most directions
+  have single-letter aliases: n, s, e, w, u, d.
+
+  LOOKING: The look command shows you the current room. Use examine on
+  objects and entities for more detail. The exits command lists all
+  available exits without the full room description.
+
+  DOORS AND PORTALS: Some exits are blocked by doors - use open and close
+  to manage them. Locked doors require the lock and unlock commands.
+  Special portals use enter and leave instead of directional movement.
+see_also: [look, examine, exits, movement, enter, leave, open, close, lock, unlock]

--- a/packs/tapestry-core/help/nofollow.yaml
+++ b/packs/tapestry-core/help/nofollow.yaml
@@ -1,0 +1,19 @@
+id: "nofollow"
+title: "Nofollow"
+category: "group"
+role: "player"
+keywords: [toggle, block, prevent, following, solo]
+brief: "Toggle whether other players can follow you."
+syntax:
+  - "nofollow"
+body: |
+  Nofollow toggles a flag on your character that prevents other players
+  from using follow on you. Use it when you want to move solo without
+  accidentally pulling someone along.
+
+  When nofollow is active, anyone who tries to follow you will be told
+  you are not accepting followers. Toggle it off to allow following again.
+
+  Using nofollow does not stop people already following you from being
+  in your group - it only blocks new follow attempts.
+see_also: [follow, group]

--- a/packs/tapestry-core/help/open.yaml
+++ b/packs/tapestry-core/help/open.yaml
@@ -1,0 +1,20 @@
+id: "open"
+title: "Open"
+category: "navigation"
+role: "player"
+keywords: [door, container, lid, unlock and open]
+brief: "Open a door or container."
+syntax:
+  - "open [direction]"
+  - "open [container]"
+body: |
+  Open is used for two things: opening a door in a given direction so
+  you can pass through, and opening a container like a chest or bag
+  to access its contents.
+
+  If the door or container is locked, you must unlock it first with
+  the unlock command.
+
+  Doors can be opened by any player in the room and will remain open
+  until closed again. Some doors close automatically.
+see_also: [close, lock, unlock, navigation]

--- a/packs/tapestry-core/help/packs.yaml
+++ b/packs/tapestry-core/help/packs.yaml
@@ -1,0 +1,20 @@
+id: "packs"
+title: "Packs"
+category: "world"
+role: "player"
+keywords: [content, credits, authors, modules, plugins, loaded]
+brief: "Show loaded content packs and their credits."
+syntax:
+  - "packs"
+body: |
+  Packs lists all content packs currently loaded in the game, their
+  version numbers, and the authors who created them.
+
+  Tapestry uses a pack system where different content creators can
+  contribute races, classes, areas, mobs, and items. The packs command
+  shows you everything currently active on the server.
+
+  Content packs are loaded in order, with higher load_order packs able
+  to override lower ones. This allows servers to customize or extend
+  base content.
+see_also: [world]

--- a/packs/tapestry-core/help/practice.yaml
+++ b/packs/tapestry-core/help/practice.yaml
@@ -1,0 +1,22 @@
+id: "practice"
+title: "Practice"
+category: "progression"
+role: "player"
+keywords: [prac, proficiency, improve, skill, spell, teacher, trainer]
+brief: "Practice with a teacher to improve skill and spell proficiency."
+syntax:
+  - "practice"
+  - "practice [skill or spell]"
+  - "prac [skill or spell]"
+body: |
+  Practice used alone shows your current proficiency in all known
+  skills and spells. Practice [name] with a teacher NPC in the room
+  spends a practice session to improve that skill or spell.
+
+  Each practice session raises proficiency by a set amount. You are
+  limited by the number of practice sessions you have available,
+  which increase as you level.
+
+  Higher proficiency means more consistent results and stronger
+  effects. Max proficiency is 100%.
+see_also: [skills, spells, train, progression]

--- a/packs/tapestry-core/help/progression.yaml
+++ b/packs/tapestry-core/help/progression.yaml
@@ -1,0 +1,22 @@
+id: "progression"
+title: "Progression"
+category: "progression"
+role: "player"
+keywords: [level, experience, xp, train, practice, advance, grow]
+brief: "How to grow your character through experience and training."
+body: |
+  Your character grows by gaining experience from combat and quests.
+  When you earn enough experience you will level up automatically.
+
+  TRAINING STATS: Each level grants a number of trains depending on
+  your class. Use train with a trainer NPC to spend trains and raise
+  your core attributes (strength, intelligence, wisdom, etc.).
+
+  PRACTICING SKILLS: Use practice (or prac) near a teacher NPC to
+  improve your proficiency with learned skills and spells. Higher
+  proficiency means more reliable results and stronger effects.
+
+  ABILITIES: New abilities are granted automatically when you reach
+  the required level for your class. Use tree to see what is coming
+  and at what level.
+see_also: [train, practice, tree, skills, spells, character]

--- a/packs/tapestry-core/help/purge.yaml
+++ b/packs/tapestry-core/help/purge.yaml
@@ -1,0 +1,20 @@
+id: "purge"
+title: "Purge"
+category: "admin"
+role: "admin"
+keywords: [remove, clear, delete, clean room, npcs, items, admin]
+brief: "Remove NPCs, items, or all entities from your current room."
+syntax:
+  - "purge"
+  - "purge [target]"
+body: |
+  Purge with no argument removes all NPCs and items from the current
+  room. Purge [target] removes a specific NPC or item by name.
+
+  Use purge to clean up rooms during testing, remove bugged NPCs,
+  or clear items left by players. Purged entities are gone permanently
+  unless respawned or re-spawned.
+
+  Be careful with purge all - it removes everything in the room and
+  cannot be undone.
+see_also: [spawn, loaditem, admin]

--- a/packs/tapestry-core/help/put.yaml
+++ b/packs/tapestry-core/help/put.yaml
@@ -1,0 +1,17 @@
+id: "put"
+title: "Put"
+category: "inventory"
+role: "player"
+keywords: [place, store, container, bag, pack, insert]
+brief: "Put an item into a container."
+syntax:
+  - "put [item] [container]"
+body: |
+  Put places an item from your inventory into a container. The container
+  can be in your inventory or on the ground in the same room.
+
+  Containers have their own weight and item limits. If the container
+  is full or the item does not fit, the command will fail.
+
+  Use get to retrieve items from a container later.
+see_also: [get, drop, inventory]

--- a/packs/tapestry-core/help/quaff.yaml
+++ b/packs/tapestry-core/help/quaff.yaml
@@ -1,0 +1,18 @@
+id: "quaff"
+title: "Quaff"
+category: "character"
+role: "player"
+keywords: [potion, drink, use, consume, magic]
+brief: "Quaff a potion from your inventory to trigger its magic effect."
+syntax:
+  - "quaff [potion]"
+body: |
+  Quaff drinks a potion from your inventory, triggering the spell
+  effect stored inside it. The potion is consumed on use.
+
+  Unlike drink, which handles ordinary liquids, quaff is specifically
+  for magic potions. The effect happens immediately on you.
+
+  Use examine on a potion before quaffing if you are unsure what it
+  does. Unknown potions are a risk.
+see_also: [drink, recite, cast, character]

--- a/packs/tapestry-core/help/quit.yaml
+++ b/packs/tapestry-core/help/quit.yaml
@@ -1,0 +1,19 @@
+id: "quit"
+title: "Quit"
+category: "world"
+role: "player"
+keywords: [qq, exit, logout, disconnect, leave game, bye]
+brief: "Disconnect from the game."
+syntax:
+  - "quit"
+  - "qq"
+body: |
+  Quit saves your character and disconnects you from the game. Your
+  progress, inventory, and position are all saved.
+
+  You cannot quit during combat. Flee first, then quit once you are
+  out of danger.
+
+  Use qq as a quick shortcut for quit. When you log back in, you will
+  return to the same room you logged out from.
+see_also: [recall, world]

--- a/packs/tapestry-core/help/read.yaml
+++ b/packs/tapestry-core/help/read.yaml
@@ -1,0 +1,20 @@
+id: "read"
+title: "Read"
+category: "world"
+role: "player"
+keywords: [sign, letter, book, text, note, inscription]
+brief: "Read a sign, letter, book, or other written item."
+syntax:
+  - "read [item]"
+  - "read [sign]"
+body: |
+  Read displays the text content of a readable item or sign in the
+  room. Many locations have signs or boards with useful information
+  about the area, quests, or lore.
+
+  Letters, books, and notes in your inventory or on the ground can
+  also be read. Some quest items require reading to advance.
+
+  Read is different from examine - examine shows an item's stats and
+  properties, while read shows its written content.
+see_also: [look, examine, world]

--- a/packs/tapestry-core/help/recall.yaml
+++ b/packs/tapestry-core/help/recall.yaml
@@ -1,0 +1,19 @@
+id: "recall"
+title: "Recall"
+category: "world"
+role: "player"
+keywords: [teleport home, safe, return, base, temple, recall room]
+brief: "Teleport to the recall room."
+syntax:
+  - "recall"
+body: |
+  Recall teleports you instantly to the designated recall room - a
+  safe central location used as a common meeting point and starting
+  place for new players.
+
+  Recall cannot be used during combat. If you are fighting, you must
+  flee first before recalling.
+
+  Some areas are "no recall" zones where the command is blocked. If
+  you find yourself stuck in one, you will need to find another way out.
+see_also: [flee, quit, world]

--- a/packs/tapestry-core/help/recite.yaml
+++ b/packs/tapestry-core/help/recite.yaml
@@ -1,0 +1,20 @@
+id: "recite"
+title: "Recite"
+category: "character"
+role: "player"
+keywords: [scroll, use, invoke, magic, paper, read aloud]
+brief: "Recite a scroll to trigger its stored spell."
+syntax:
+  - "recite [scroll]"
+  - "recite [scroll] [target]"
+body: |
+  Recite reads a scroll aloud and triggers the spell encoded within it.
+  The scroll is consumed after use. Some scrolls target a specific
+  entity and require a target argument.
+
+  Unlike quaff (which always affects you), scroll spells can target
+  others - useful for healing allies or applying debuffs to enemies.
+
+  Recite success can depend on your level or intelligence. Low stats
+  increase the chance of misfire or failure.
+see_also: [quaff, cast, character]

--- a/packs/tapestry-core/help/remove.yaml
+++ b/packs/tapestry-core/help/remove.yaml
@@ -1,0 +1,18 @@
+id: "remove"
+title: "Remove"
+category: "equipment"
+role: "player"
+keywords: [unequip, take off, unwield, dequip]
+brief: "Remove a worn or wielded item and return it to inventory."
+syntax:
+  - "remove [item]"
+body: |
+  Remove unequips a worn or wielded item and places it back in your
+  inventory. You can reference the item by its name or slot.
+
+  You cannot remove items during certain states - some cursed items
+  cannot be removed at all without a remove curse effect.
+
+  Use equipment (or eq) to see what you have equipped and the slot
+  names before using remove.
+see_also: [wear, wield, equipment]

--- a/packs/tapestry-core/help/reply.yaml
+++ b/packs/tapestry-core/help/reply.yaml
@@ -1,0 +1,19 @@
+id: "reply"
+title: "Reply"
+category: "communication"
+role: "player"
+keywords: [respond, answer, r, tell back]
+brief: "Reply to the last player who sent you a tell."
+syntax:
+  - "reply [message]"
+  - "r [message]"
+body: |
+  Reply sends a tell back to the last player who messaged you, without
+  needing to type their name. It is a shortcut for tell [last-sender].
+
+  If no one has sent you a tell yet this session, reply will fail and
+  notify you. The reply target resets each session.
+
+  Use tell if you want to start a conversation or message someone who
+  has not told you first.
+see_also: [tell, say, communication]

--- a/packs/tapestry-core/help/rescue.yaml
+++ b/packs/tapestry-core/help/rescue.yaml
@@ -1,0 +1,19 @@
+id: "rescue"
+title: "Rescue"
+category: "combat"
+role: "player"
+keywords: [save, protect, pull aggro, tank, group combat]
+brief: "Rescue an ally from combat, redirecting the enemy to you."
+syntax:
+  - "rescue [ally]"
+body: |
+  Rescue pulls an enemy off an ally who is being attacked, redirecting
+  the combat to you instead. The ally is freed from the fight and you
+  become the new target.
+
+  Rescue is essential for tanks and front-line fighters in a group.
+  Use it to protect healers, mages, or weaker allies from taking damage.
+
+  Rescue requires you to be in the same room as both the ally and the
+  enemy. Success is not always guaranteed.
+see_also: [kill, group, combat]

--- a/packs/tapestry-core/help/rest.yaml
+++ b/packs/tapestry-core/help/rest.yaml
@@ -1,0 +1,25 @@
+id: "rest"
+title: "Rest"
+category: "rest"
+role: "player"
+keywords: [sleep, wake, stand, recover, regen, regenerate, hp, restore]
+brief: "Rest and sleep to recover HP, resource, and movement."
+syntax:
+  - "rest"
+  - "sleep"
+  - "wake"
+  - "stand"
+body: |
+  Your HP, resource, and movement points regenerate over time, but
+  resting or sleeping speeds up recovery significantly.
+
+  REST: Sitting down to rest increases your regeneration rate. You can
+  still interact with the world while resting, but you cannot move or
+  fight without standing first.
+
+  SLEEP: Sleeping provides the fastest regeneration. While asleep you
+  cannot act. Use wake (or stand) to get up.
+
+  You cannot rest or sleep during combat. If you are attacked while
+  resting or sleeping, you will be forced to stand.
+see_also: [sleep, wake]

--- a/packs/tapestry-core/help/say.yaml
+++ b/packs/tapestry-core/help/say.yaml
@@ -2,7 +2,7 @@ id: "say"
 title: "Say"
 category: "communication"
 role: "player"
-keywords: [speak, talk, local, room, chat, ']
+keywords: [speak, talk, local, room, chat]
 brief: "Speak to everyone in your current room."
 syntax:
   - "say [message]"

--- a/packs/tapestry-core/help/say.yaml
+++ b/packs/tapestry-core/help/say.yaml
@@ -1,0 +1,18 @@
+id: "say"
+title: "Say"
+category: "communication"
+role: "player"
+keywords: [speak, talk, local, room, chat, ']
+brief: "Speak to everyone in your current room."
+syntax:
+  - "say [message]"
+  - "' [message]"
+body: |
+  Say sends your message to everyone in the same room. NPCs and players
+  alike can hear it. Use the apostrophe (') as a shortcut.
+
+  Say is local only - players in other rooms cannot hear you. For
+  messages that cross rooms, use gossip, yell, or tell.
+
+  Your speech appears as: You say, 'message here.'
+see_also: [emote, tell, gossip, yell, communication]

--- a/packs/tapestry-core/help/score.yaml
+++ b/packs/tapestry-core/help/score.yaml
@@ -1,0 +1,20 @@
+id: "score"
+title: "Score"
+category: "character"
+role: "player"
+keywords: [stats, status, sheet, info, level, hp, xp, experience, attributes]
+brief: "Display your character stats and status."
+syntax:
+  - "score"
+body: |
+  Score displays your full character sheet: name, race, class, level,
+  experience, HP, resource, movement, gold, and all core attributes
+  (strength, intelligence, wisdom, dexterity, constitution, luck).
+
+  It also shows secondary values derived from your attributes and
+  equipment: armor class, hit roll, damage roll, and any relevant
+  modifiers.
+
+  Check score regularly after leveling, equipping new gear, or gaining
+  stat-affecting buffs to understand how your character has changed.
+see_also: [affects, character, progression]

--- a/packs/tapestry-core/help/screen-reader.yaml
+++ b/packs/tapestry-core/help/screen-reader.yaml
@@ -1,0 +1,28 @@
+id: "screen-reader"
+title: "Screen Reader Support"
+category: "accessibility"
+role: "player"
+keywords: [blind, vi, nvda, jaws, voiceover, aria, live region, announce, narrate]
+brief: "How the Tapestry web client supports screen readers and blind players."
+body: |
+  The Tapestry web client is built to work alongside screen readers
+  from the ground up, not as an afterthought.
+
+  LIVE ANNOUNCEMENTS: Room descriptions, combat events, tells, and
+  other key game events are pushed through ARIA live regions. Your
+  screen reader picks these up automatically as they happen - you do
+  not need to navigate to them.
+
+  MODALS: Help topics, inventory panels, and other information windows
+  open as accessible modals. Focus moves into the modal automatically,
+  all elements are reachable via Tab, and pressing Escape closes the
+  modal and returns focus to where you were.
+
+  KEYBOARD ONLY: Every interactive element in the client - links,
+  buttons, input fields - is fully keyboard accessible. No mouse
+  is needed to play.
+
+  STRUCTURED DATA: The server uses GMCP to send structured game data
+  separate from the text stream. This powers screen-reader-friendly
+  panels for inventory, room info, and help topics.
+see_also: [keyboard-shortcuts, gmcp-overview, accessibility]

--- a/packs/tapestry-core/help/sell.yaml
+++ b/packs/tapestry-core/help/sell.yaml
@@ -1,0 +1,18 @@
+id: "sell"
+title: "Sell"
+category: "shop"
+role: "player"
+keywords: [trade, pawn, merchant, money, gold, unload]
+brief: "Sell an item to a shop."
+syntax:
+  - "sell [item]"
+body: |
+  Sell removes an item from your inventory and gives you gold in return
+  based on the shop's appraisal. The item must be in your inventory.
+
+  Not every shop buys everything. Use value first to check whether the
+  merchant is interested and how much they will pay.
+
+  Shops buy items at a fraction of their full value. If you need a
+  better price, look for a specialized merchant.
+see_also: [value, buy, list, shop]

--- a/packs/tapestry-core/help/set.yaml
+++ b/packs/tapestry-core/help/set.yaml
@@ -1,0 +1,19 @@
+id: "set"
+title: "Set"
+category: "admin"
+role: "admin"
+keywords: [modify, edit, field, property, player, npc, item, admin]
+brief: "Modify player, NPC, or item fields directly."
+syntax:
+  - "set [target] [field] [value]"
+body: |
+  Set modifies a specific field on a player, NPC, or item. The field
+  names and valid values depend on the entity type.
+
+  Common uses: adjusting HP, gold, level, or stat values for testing
+  or support. Use inspect first to see the available fields and
+  current values on a target.
+
+  Changes made with set take effect immediately. Some fields may
+  require a save or relog to persist across sessions.
+see_also: [inspect, grant, admin]

--- a/packs/tapestry-core/help/setclass.yaml
+++ b/packs/tapestry-core/help/setclass.yaml
@@ -1,0 +1,16 @@
+id: "setclass"
+title: "Setclass"
+category: "admin"
+role: "admin"
+keywords: [class, assign, reset, level 1 abilities, admin]
+brief: "Assign a class to a player and grant their level-1 abilities."
+syntax:
+  - "setclass [player] [class]"
+body: |
+  Setclass assigns a class to the named player and automatically grants
+  all abilities that class gives at level 1. Existing abilities are
+  not removed - use forget first if you need a clean slate.
+
+  Use setclass when correcting a player's class, testing a class
+  from scratch, or setting up test characters.
+see_also: [learn, forget, admin]

--- a/packs/tapestry-core/help/settrainable.yaml
+++ b/packs/tapestry-core/help/settrainable.yaml
@@ -1,0 +1,16 @@
+id: "settrainable"
+title: "Settrainable"
+category: "admin"
+role: "admin"
+keywords: [debug, stat, trainable, toggle, runtime, admin]
+brief: "Runtime debug: toggle a stat in or out of the trainable list."
+syntax:
+  - "settrainable [stat]"
+body: |
+  Settrainable is a runtime debug tool that toggles a stat between
+  trainable and non-trainable status. Changes affect all players
+  immediately but are not persistent across server restarts.
+
+  Use this for testing train mechanics or temporarily restricting
+  which stats can be trained during a content iteration.
+see_also: [train, set, admin]

--- a/packs/tapestry-core/help/shop.yaml
+++ b/packs/tapestry-core/help/shop.yaml
@@ -1,0 +1,23 @@
+id: "shop"
+title: "Shop"
+category: "shop"
+role: "player"
+keywords: [store, buy, sell, merchant, vendor, trade, purchase]
+brief: "How to buy and sell items at shops."
+body: |
+  Shops are run by merchant NPCs found throughout the world. Each shop
+  carries a different stock of items and will buy different things from
+  players.
+
+  BROWSING: Use list to see what is available for sale and the prices.
+  Some shops have more items than fit on one page.
+
+  BUYING: Use buy [item] to purchase something. The cost is deducted
+  from your gold. You need enough gold and free carry capacity.
+
+  SELLING: Use sell [item] to sell something from your inventory. Use
+  value [item] first to check how much the shop will pay before selling.
+
+  Shops do not always buy everything you carry. If a shop is not
+  interested in an item, value will tell you.
+see_also: [list, buy, sell, value]

--- a/packs/tapestry-core/help/skills.yaml
+++ b/packs/tapestry-core/help/skills.yaml
@@ -1,0 +1,19 @@
+id: "skills"
+title: "Skills"
+category: "character"
+role: "player"
+keywords: [abilities, proficiency, learned, combat skills, physical]
+brief: "Show your learned skills and their proficiency levels."
+syntax:
+  - "skills"
+body: |
+  Skills lists every physical or combat skill you have learned, along
+  with your current proficiency percentage in each.
+
+  Higher proficiency means the skill fires more reliably and may hit
+  harder or apply effects more consistently. Improve proficiency by
+  using practice near a teacher NPC.
+
+  Skills are learned automatically as you level up based on your class.
+  Use tree to see what is coming and at what level you gain each ability.
+see_also: [spells, tree, practice, character]

--- a/packs/tapestry-core/help/sleep.yaml
+++ b/packs/tapestry-core/help/sleep.yaml
@@ -1,0 +1,19 @@
+id: "sleep"
+title: "Sleep"
+category: "rest"
+role: "player"
+keywords: [rest, recover, regenerate, nap, pass out]
+brief: "Lie down and sleep to recover HP, resource, and movement quickly."
+syntax:
+  - "sleep"
+body: |
+  Sleep puts your character into a sleep state, providing the fastest
+  regeneration rate for HP, resource, and movement. You cannot act
+  while asleep.
+
+  To wake up, use wake or stand. You will also be woken by being
+  attacked or by certain events in the room.
+
+  Do not sleep in dangerous areas - you cannot defend yourself while
+  sleeping and will take a round of hits before waking if attacked.
+see_also: [rest, wake]

--- a/packs/tapestry-core/help/social.yaml
+++ b/packs/tapestry-core/help/social.yaml
@@ -1,0 +1,28 @@
+id: "social"
+title: "Socials"
+category: "social"
+role: "player"
+keywords: [emote, action, gesture, expression, roleplay, rp]
+brief: "Pre-written emotes and gestures to express yourself in the world."
+body: |
+  Socials are built-in emote actions you can perform with a single command.
+  Each social has a message shown to you, one shown to the room, and
+  optionally a targeted version if you name a player or NPC.
+
+  Use a social by typing its name alone or followed by a target:
+    wave
+    wave merchant
+    bow reginald
+
+  Available socials include: ack, applaud, bark, beam, blush, boggle,
+  bonk, bounce, bow, burp, cackle, cheer, chuckle, clap, comb, comfort,
+  cough, cringe, cry, cuddle, curse, dance, drool, eye, faint, flex,
+  flip, flirt, flutter, frown, gasp, giggle, glare, grin, groan, growl,
+  grumble, grunt, hide, hmm, hop, howl, hug, kiss, kneel, laugh, lick,
+  mock, mutter, nibble, nod, nudge, pat, peer, poke, ponder, pout,
+  purr, roar, ruffle, salute, scowl, shake, shrug, sigh, slap, smile,
+  smirk, snap, snicker, sniff, sob, spit, sulk, tackle, tap, thank,
+  think, tickle, wave, whine, whistle, wink, worship, yawn.
+
+  For freeform actions, use emote to write your own.
+see_also: [emote]

--- a/packs/tapestry-core/help/spawn.yaml
+++ b/packs/tapestry-core/help/spawn.yaml
@@ -1,0 +1,16 @@
+id: "spawn"
+title: "Spawn"
+category: "admin"
+role: "admin"
+keywords: [create mob, npc, summon, template, admin]
+brief: "Spawn a mob from a template ID into your current room."
+syntax:
+  - "spawn [template-id]"
+body: |
+  Spawn creates an NPC instance from the given mob template ID and
+  places it in your current room. Use it to test mob behavior, populate
+  areas during development, or restore NPCs removed by purge.
+
+  Template IDs follow the format "pack:mob-id". Use inspect on an
+  existing mob to find its template ID.
+see_also: [purge, loaditem, admin]

--- a/packs/tapestry-core/help/spells.yaml
+++ b/packs/tapestry-core/help/spells.yaml
@@ -1,0 +1,19 @@
+id: "spells"
+title: "Spells"
+category: "character"
+role: "player"
+keywords: [magic, abilities, learned, proficiency, arcane, mana]
+brief: "Show your learned spells and their proficiency levels."
+syntax:
+  - "spells"
+body: |
+  Spells lists every spell you have learned, along with your current
+  proficiency in each. Spell proficiency affects cast reliability,
+  effect magnitude, and in some cases the cost to cast.
+
+  Spells are learned automatically at level milestones defined by your
+  class. Use tree to see your full list and when each is unlocked.
+
+  Improve spell proficiency with the practice command near a teacher.
+  Use cast to invoke a spell in the world.
+see_also: [skills, tree, practice, cast, character]

--- a/packs/tapestry-core/help/teleport.yaml
+++ b/packs/tapestry-core/help/teleport.yaml
@@ -1,0 +1,22 @@
+id: "teleport"
+title: "Teleport"
+category: "admin"
+role: "admin"
+keywords: [tp, warp, goto, move, jump, admin]
+brief: "Teleport yourself or another player to a room or player."
+syntax:
+  - "teleport [room-id]"
+  - "teleport [player]"
+  - "tp [room-id]"
+  - "tp [player]"
+body: |
+  Teleport moves you instantly to a target room by ID or to another
+  player's location. With a player name as the second argument, it
+  moves that player to you or to the specified destination.
+
+  Room IDs follow the pack format: "pack:room-id". Use inspect on
+  your current room to find its ID.
+
+  Use teleport for world navigation during building, responding to
+  player requests, and testing area layouts.
+see_also: [spawn, admin]

--- a/packs/tapestry-core/help/tell.yaml
+++ b/packs/tapestry-core/help/tell.yaml
@@ -1,0 +1,19 @@
+id: "tell"
+title: "Tell"
+category: "communication"
+role: "player"
+keywords: [private, message, whisper, pm, t]
+brief: "Send a private message to a player by name."
+syntax:
+  - "tell [player] [message]"
+  - "t [player] [message]"
+body: |
+  Tell sends a private message to a specific player anywhere in the
+  world. Only you and the recipient see the message.
+
+  If the player is not online, the tell will fail and you will be
+  notified. Player names are not case-sensitive.
+
+  Use reply to respond to the most recent tell you received without
+  typing the player's name again.
+see_also: [reply, say, gossip, communication]

--- a/packs/tapestry-core/help/time.yaml
+++ b/packs/tapestry-core/help/time.yaml
@@ -1,0 +1,18 @@
+id: "time"
+title: "Time"
+category: "world"
+role: "player"
+keywords: [clock, date, day, night, in-game time, hour]
+brief: "Show the current in-game time."
+syntax:
+  - "time"
+body: |
+  Time displays the current in-game time of day and date. Tapestry
+  uses a separate game calendar that advances independently of real time.
+
+  Time of day can affect certain spells, mob behavior, shop hours, and
+  world events depending on how the server is configured.
+
+  Use weather alongside time to get a full picture of current world
+  conditions.
+see_also: [weather, world]

--- a/packs/tapestry-core/help/train.yaml
+++ b/packs/tapestry-core/help/train.yaml
@@ -1,0 +1,21 @@
+id: "train"
+title: "Train"
+category: "progression"
+role: "player"
+keywords: [stat, attribute, trains, raise, strength, intelligence, dexterity]
+brief: "Spend a train to permanently raise a core attribute."
+syntax:
+  - "train"
+  - "train [stat]"
+body: |
+  Train used alone shows your available trains and current stat values.
+  Train [stat] spends one train to permanently raise that attribute
+  by one point, up to your race's maximum cap.
+
+  Stats you can train include: strength, intelligence, wisdom, dexterity,
+  constitution, and luck. Trains are granted each time you level up,
+  with the amount depending on your class.
+
+  Choose carefully - trains are limited and stats near their cap
+  become more valuable. Focus on the stats your class relies on most.
+see_also: [practice, score, progression]

--- a/packs/tapestry-core/help/tree.yaml
+++ b/packs/tapestry-core/help/tree.yaml
@@ -1,0 +1,19 @@
+id: "tree"
+title: "Tree"
+category: "character"
+role: "player"
+keywords: [class path, ability tree, progression tree, unlock, levels]
+brief: "Show your class path and learned abilities by level."
+syntax:
+  - "tree"
+body: |
+  Tree displays your full class progression path: every ability your
+  class can learn, what level it is unlocked at, and whether you have
+  learned it yet.
+
+  Use tree to plan your progression, understand what is coming next,
+  and confirm what you have already unlocked.
+
+  Abilities shown as learned match what appears in skills and spells.
+  Abilities not yet reached show their unlock level as a milestone.
+see_also: [skills, spells, practice, progression, character]

--- a/packs/tapestry-core/help/unlink.yaml
+++ b/packs/tapestry-core/help/unlink.yaml
@@ -1,0 +1,19 @@
+id: "unlink"
+title: "Unlink"
+category: "builder"
+role: "builder"
+keywords: [remove exit, disconnect, delete link, builder]
+brief: "Remove an exit connection from the current room."
+syntax:
+  - "unlink [direction]"
+body: |
+  Unlink removes the exit in the specified direction from the current
+  room. The destination room is not affected - only the exit from this
+  room is removed.
+
+  If the connection was two-way, you will need to unlink the return
+  direction from the destination room separately.
+
+  Use connections before unlinking to confirm which direction you
+  want to remove.
+see_also: [link, connections, builder]

--- a/packs/tapestry-core/help/unlock.yaml
+++ b/packs/tapestry-core/help/unlock.yaml
@@ -1,0 +1,19 @@
+id: "unlock"
+title: "Unlock"
+category: "navigation"
+role: "player"
+keywords: [key, open, door, container]
+brief: "Unlock a door or container."
+syntax:
+  - "unlock [direction]"
+  - "unlock [container]"
+body: |
+  Unlock removes the lock from a door or container so it can be
+  opened. You must have the appropriate key in your inventory.
+
+  After unlocking, use open to pass through the door or access the
+  container's contents.
+
+  If you do not have the right key, you will need to find it or
+  find another way past the obstacle.
+see_also: [lock, open, close, navigation]

--- a/packs/tapestry-core/help/value.yaml
+++ b/packs/tapestry-core/help/value.yaml
@@ -1,0 +1,19 @@
+id: "value"
+title: "Value"
+category: "shop"
+role: "player"
+keywords: [appraise, worth, price, gold, check, offer]
+brief: "Check how much a shop will pay for an item."
+syntax:
+  - "value [item]"
+body: |
+  Value asks the merchant in your room how much they would pay for an
+  item from your inventory. It does not sell the item - it is just a
+  quote.
+
+  Use value before selling to avoid surprises. If the shop is not
+  interested in the item at all, value tells you that too.
+
+  Some items are worth significantly more to specialized merchants.
+  If value returns a low number, try a different shop.
+see_also: [sell, buy, list, shop]

--- a/packs/tapestry-core/help/wake.yaml
+++ b/packs/tapestry-core/help/wake.yaml
@@ -1,0 +1,19 @@
+id: "wake"
+title: "Wake"
+category: "rest"
+role: "player"
+keywords: [stand, get up, rise, stop resting, stop sleeping]
+brief: "Wake up and stand, ending rest or sleep."
+syntax:
+  - "wake"
+  - "stand"
+body: |
+  Wake (or stand) brings you to your feet from a resting or sleeping
+  state. You must be standing to move, fight, or use most commands.
+
+  If you are sleeping, wake brings you to standing immediately. If
+  you are resting, stand also works.
+
+  You are automatically woken if you are attacked while resting or
+  sleeping.
+see_also: [rest, sleep]

--- a/packs/tapestry-core/help/wear.yaml
+++ b/packs/tapestry-core/help/wear.yaml
@@ -1,0 +1,20 @@
+id: "wear"
+title: "Wear"
+category: "equipment"
+role: "player"
+keywords: [equip, put on, armor, clothing, slot]
+brief: "Wear an item from your inventory."
+syntax:
+  - "wear [item]"
+body: |
+  Wear equips an armor, clothing, or accessory item from your inventory,
+  placing it in the appropriate equipment slot.
+
+  If the target slot is already occupied, you must remove the existing
+  item first before wearing a new one in its place.
+
+  Some items have level or stat requirements. If you do not meet them,
+  the wear command will fail with an explanation.
+
+  Use equipment (or eq) to see what you currently have equipped.
+see_also: [wield, remove, equipment]

--- a/packs/tapestry-core/help/weather.yaml
+++ b/packs/tapestry-core/help/weather.yaml
@@ -1,0 +1,18 @@
+id: "weather"
+title: "Weather"
+category: "world"
+role: "player"
+keywords: [climate, storm, rain, sun, conditions, forecast]
+brief: "Show the current weather conditions."
+syntax:
+  - "weather"
+body: |
+  Weather displays the current conditions in the game world. Conditions
+  cycle naturally over time and may vary by region depending on how
+  the server is configured.
+
+  Weather can affect outdoor movement, certain spells that call upon
+  nature or lightning, and the atmosphere of exploration.
+
+  Use time alongside weather for full context on current world state.
+see_also: [time, world]

--- a/packs/tapestry-core/help/who.yaml
+++ b/packs/tapestry-core/help/who.yaml
@@ -1,0 +1,19 @@
+id: "who"
+title: "Who"
+category: "world"
+role: "player"
+keywords: [players, online, connected, list, people]
+brief: "List players currently online."
+syntax:
+  - "who"
+body: |
+  Who displays a list of all players currently connected to the game.
+  Each entry typically shows the player's level, class, race, and name.
+
+  Admin and builder players may appear with their role indicated.
+  Some players may have titles or clan tags displayed alongside
+  their name.
+
+  Use who to find out who is around for grouping, trading, or just
+  to see how busy the server is.
+see_also: [gossip, tell, world]

--- a/packs/tapestry-core/help/wield.yaml
+++ b/packs/tapestry-core/help/wield.yaml
@@ -1,0 +1,19 @@
+id: "wield"
+title: "Wield"
+category: "equipment"
+role: "player"
+keywords: [weapon, hold, equip, sword, main hand, offhand]
+brief: "Wield a weapon from your inventory."
+syntax:
+  - "wield [weapon]"
+body: |
+  Wield equips a weapon from your inventory into your main hand. Some
+  classes or builds may allow dual-wielding a second weapon as well.
+
+  If you already have a weapon wielded, wield will swap it out with
+  the new one. The old weapon returns to your inventory.
+
+  Wielding a better weapon is one of the most direct ways to improve
+  your combat effectiveness. Use examine on weapons to compare stats
+  before committing.
+see_also: [wear, remove, equipment]

--- a/packs/tapestry-core/help/wimpy.yaml
+++ b/packs/tapestry-core/help/wimpy.yaml
@@ -1,0 +1,21 @@
+id: "wimpy"
+title: "Wimpy"
+category: "combat"
+role: "player"
+keywords: [auto flee, threshold, safety, hp limit, coward]
+brief: "Set HP threshold to automatically flee combat."
+syntax:
+  - "wimpy"
+  - "wimpy [hp]"
+  - "wimpy 0"
+body: |
+  Wimpy sets an HP threshold below which you will automatically attempt
+  to flee from combat. This is a critical safety setting for solo play.
+
+  Set it with "wimpy [number]" where the number is an HP value, not
+  a percentage. When your HP drops to that level or below during combat,
+  a flee attempt fires automatically.
+
+  Use "wimpy 0" to disable automatic fleeing. Use "wimpy" alone to
+  see your current setting.
+see_also: [flee, kill, combat]

--- a/packs/tapestry-core/help/world.yaml
+++ b/packs/tapestry-core/help/world.yaml
@@ -1,0 +1,24 @@
+id: "world"
+title: "World"
+category: "world"
+role: "player"
+keywords: [general, misc, commands, online, time, weather]
+brief: "General world commands: who is online, time, weather, and more."
+body: |
+  These commands give you information about the world and your place in it.
+
+  PLAYERS: who lists everyone currently connected. Use packs to see
+  what content is loaded and who created it.
+
+  WORLD STATE: time shows the current in-game time of day and date.
+  weather shows current conditions, which can affect travel and some spells.
+
+  INFORMATION: motd shows the message of the day, which admins use to
+  share news and announcements. commands (or cmds) lists all commands
+  currently available to you.
+
+  TRAVEL: recall teleports you back to the recall room - a safe point
+  in the world used as a common meeting place.
+
+  LEAVING: quit (or qq) disconnects you cleanly. Your character is saved.
+see_also: [who, time, weather, motd, packs, commands, help, recall, quit]

--- a/packs/tapestry-core/help/yell.yaml
+++ b/packs/tapestry-core/help/yell.yaml
@@ -1,0 +1,16 @@
+id: "yell"
+title: "Yell"
+category: "communication"
+role: "player"
+keywords: [shout, area, loud, nearby]
+brief: "Shout a message to everyone in the current area."
+syntax:
+  - "yell [message]"
+body: |
+  Yell sends your message to all players in the same area (zone) as
+  you, but not to players in other parts of the world.
+
+  Use yell when you need to reach nearby players quickly - calling for
+  help in a dungeon, warning others about danger, or coordinating
+  without bothering the whole server with gossip.
+see_also: [gossip, say, tell, communication]

--- a/packs/tapestry-core/scripts/commands/help.js
+++ b/packs/tapestry-core/scripts/commands/help.js
@@ -18,13 +18,25 @@ tapestry.commands.register({
             }
 
             var lines = ['Help Topics:\r\n'];
+            var matches = [];
             for (var i = 0; i < cats.length; i++) {
                 var cat = String(cats[i]);
                 var topics = helpId ? tapestry.help.list(helpId, cat) : tapestry.help.list(cat);
-                lines.push('  ' + cat + ' (' + topics.length + (topics.length === 1 ? ' topic' : ' topics') + ')\r\n');
+                var count = topics.length;
+                lines.push('  ' + cat + ' (' + count + (count === 1 ? ' topic' : ' topics') + ')\r\n');
+                matches.push({
+                    id: cat,
+                    title: cat.charAt(0).toUpperCase() + cat.slice(1),
+                    brief: count + (count === 1 ? ' topic' : ' topics')
+                });
             }
             lines.push('\r\nType help [topic] for details.\r\n');
             player.send(lines.join(''));
+            tapestry.gmcp.send(player.entityId, 'Response.Help', {
+                status: 'multiple',
+                term: '',
+                matches: matches
+            });
             return;
         }
 


### PR DESCRIPTION
## Summary

- Add help YAML files for all commands and topics across both packs (tapestry-core + example-pack)
- Fix unquoted special characters in keyword lists for emote and say help files
- Fix help modal GMCP handling for category lists and one-behind announce bug
- Restructure help modal for clean NVDA screen reader reading order:
  - DOM ordered: heading → brief → syntax → body (aria-hidden) → see-also buttons → sr-only hints → close button
  - Replace `<header>` with `<div>` to suppress unwanted banner landmark
  - Route Alt+H full-text read through in-dialog assertive region (works within `showModal()` scope)
  - Remount dialog on each `openHelp` via `dialogKey` so NVDA gets a fresh dialog scan on every navigation
  - Guard `commandBarStore.requestFocus` when help modal is open to prevent focus stealing
  - Disambiguation page shows "Select a category:" instead of "type help [topic]" (user is in modal, can't type)

## Test plan

- [x] `help` shows top-level category list, Tab through buttons works
- [x] `help combat` shows topic with brief, syntax, see-also
- [x] Click see-also link navigates to new topic (NVDA re-reads full dialog)
- [x] Alt+H reads full help body text without brief
- [x] Escape closes modal and returns focus to command bar
- [x] Room announcements, combat, chat announcements still work while modal is closed
- [x] All 349 client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)