### PR TITLE
feat: idle timeout, sac command, gold-on-kill

### DIFF
--- a/packs/tapestry-core/scripts/commands/sac.js
+++ b/packs/tapestry-core/scripts/commands/sac.js
@@ -1,0 +1,56 @@
+tapestry.commands.register({
+    name: 'sac',
+    aliases: ['sacrifice'],
+    description: 'Sacrifice a corpse to remove it from the world.',
+    priority: 0,
+    handler: function(player, args) {
+        if (args.length === 0) {
+            player.send('Sacrifice what?\r\n');
+            return;
+        }
+
+        var keyword = args.join(' ');
+        var found = tapestry.inventory.findInRoom(player.entityId, keyword);
+        if (!found) {
+            player.send("You don't see that here.\r\n");
+            return;
+        }
+
+        if (!tapestry.world.hasTag(found.id, 'corpse')) {
+            player.send("You can only sacrifice corpses.\r\n");
+            return;
+        }
+
+        if (tapestry.world.hasTag(found.id, 'player_corpse')) {
+            var contents = tapestry.inventory.getContents(found.id);
+            if (contents.length > 0) {
+                player.send("You cannot sacrifice a player corpse that still has belongings in it.\r\n");
+                return;
+            }
+        }
+
+        var corpseName = found.name;
+        var isPlayerCorpse = tapestry.world.hasTag(found.id, 'player_corpse');
+        var corpseEntity = tapestry.world.getEntity(found.id);
+        var level = corpseEntity && corpseEntity.properties ? (corpseEntity.properties.level || 0) : 0;
+
+        destroyWithContents(found.id);
+
+        player.send('You sacrifice ' + corpseName + ' to the heavens.\r\n');
+        player.sendToRoom(player.name + ' sacrifices ' + corpseName + ' to the heavens.\r\n');
+
+        if (!isPlayerCorpse && level > 0) {
+            tapestry.currency.addGold(player.entityId, level, "sac");
+            var coinWord = level === 1 ? 'coin' : 'coins';
+            player.send('The heavens reward you with ' + level + ' gold ' + coinWord + '.\r\n');
+        }
+    }
+});
+
+function destroyWithContents(entityId) {
+    var contents = tapestry.inventory.getContents(entityId);
+    for (var i = 0; i < contents.length; i++) {
+        destroyWithContents(contents[i].id);
+    }
+    tapestry.world.removeEntity(entityId);
+}

--- a/packs/tapestry-core/scripts/mobs/death.js
+++ b/packs/tapestry-core/scripts/mobs/death.js
@@ -23,6 +23,7 @@ tapestry.events.on("entity.vital.depleted", function(event) {
     tapestry.world.setProperty(corpseId, "corpse_decay", corpseDecay);
     tapestry.world.setProperty(corpseId, "corpse_created_tick", tapestry.world.getCurrentTick());
     tapestry.world.setProperty(corpseId, "template_id", templateId);
+    tapestry.world.setProperty(corpseId, "level", entity.properties ? (entity.properties.level || 1) : 1);
 
     // Transfer equipment and inventory to corpse
     tapestry.inventory.transferAll(event.sourceEntityId, corpseId);
@@ -37,11 +38,26 @@ tapestry.events.on("entity.vital.depleted", function(event) {
     // Notify room
     tapestry.world.sendToRoom(roomId, mobName + " has died!\r\n");
 
+    // Award gold to killer if mob has gold_min/gold_max properties
+    var killerId = event.data ? event.data.killerId : null;
+    var goldMin = entity.properties ? entity.properties.gold_min : null;
+    var goldMax = entity.properties ? entity.properties.gold_max : null;
+    if (killerId && goldMin != null) {
+        var max = goldMax != null ? parseInt(goldMax) : parseInt(goldMin);
+        var min = parseInt(goldMin);
+        var goldDrop = Math.floor(Math.random() * (max - min + 1)) + min;
+        if (goldDrop > 0) {
+            tapestry.currency.addGold(killerId, goldDrop, "mob_kill");
+            var coinWord = goldDrop === 1 ? "coin" : "coins";
+            tapestry.world.sendToPlayer(killerId, "You receive " + goldDrop + " gold " + coinWord + ".\r\n");
+        }
+    }
+
     // Publish death event for other systems
     tapestry.events.publish("mob.death", {
         templateId: templateId,
         roomId: roomId,
         corpseId: corpseId,
-        killerId: event.data ? event.data.killerId : null
+        killerId: killerId
     });
 });

--- a/src/Tapestry.Data/ServerConfig.cs
+++ b/src/Tapestry.Data/ServerConfig.cs
@@ -18,6 +18,7 @@ public class ServerConfig
     public EconomySection Economy { get; set; } = new();
     public GameSection Game { get; set; } = new();
     public MsspConfig Mssp { get; set; } = new();
+    public IdleSection Idle { get; set; } = new();
 
     public string ConfigDirectory { get; private set; } = "";
 
@@ -145,6 +146,16 @@ public class TrainingSection
         "strength", "intelligence", "wisdom", "dexterity", "constitution", "luck"
     };
     public int CatchUpBoost { get; set; } = 5;
+}
+
+public class IdleSection
+{
+    public int WarnSeconds { get; set; } = 0;
+    public int TimeoutSeconds { get; set; } = 0;
+    public int PreLoginTimeoutSeconds { get; set; } = 120;
+    public string WarnMessage { get; set; } = "The world grows distant... you are fading.";
+    public string TimeoutMessage { get; set; } = "You have faded from the world.";
+    public string AdminTag { get; set; } = "admin";
 }
 
 public class GameSection

--- a/src/Tapestry.Engine/GameLoop.cs
+++ b/src/Tapestry.Engine/GameLoop.cs
@@ -17,6 +17,7 @@ public class GameLoop
     private readonly SystemEventQueue _eventQueue;
     private readonly ILogger<GameLoop> _logger;
     private readonly TapestryMetrics _metrics;
+    private readonly TickTimer _timer;
     private readonly HashSet<Guid> _activeDisconnects = new();
     private readonly List<TickHandler> _tickHandlers = new();
     private readonly ConcurrentQueue<Action> _pendingActions = new();
@@ -35,7 +36,7 @@ public class GameLoop
 
     public GameLoop(CommandRouter router, SessionManager sessions, EventBus eventBus,
                     SystemEventQueue eventQueue, ILogger<GameLoop> logger,
-                    TapestryMetrics metrics)
+                    TapestryMetrics metrics, TickTimer timer)
     {
         _router = router;
         _sessions = sessions;
@@ -43,6 +44,7 @@ public class GameLoop
         _eventQueue = eventQueue;
         _logger = logger;
         _metrics = metrics;
+        _timer = timer;
     }
 
     public void Schedule(Action action)
@@ -60,10 +62,10 @@ public class GameLoop
         _tickHandlers.Add(new TickHandler(name, intervalTicks, handler));
     }
 
-    public void ConfigureIdleTimeout(int timeoutSeconds, int tickRateMs)
+    public void ConfigureIdleTimeout(int warnSeconds, int timeoutSeconds)
     {
-        _idleTimeoutTicks = (timeoutSeconds * 1000) / tickRateMs;
-        _idleWarningTicks = (int)(_idleTimeoutTicks * 0.8);
+        _idleWarningTicks = warnSeconds > 0 ? (int)_timer.SecondsToTicks(warnSeconds) : 0;
+        _idleTimeoutTicks = timeoutSeconds > 0 ? (int)_timer.SecondsToTicks(timeoutSeconds) : 0;
     }
 
     public void Tick()
@@ -257,13 +259,16 @@ public class GameLoop
         }
     }
 
-    public void RegisterIdleTimeoutHandler(SystemEventQueue eventQueue, SessionManager sessions)
+    public void RegisterIdleTimeoutHandler(SystemEventQueue eventQueue, SessionManager sessions,
+        string warnMessage, string timeoutMessage, string adminTag = "admin")
     {
         // Check every 300 ticks (~30 seconds at 100ms tick rate)
         RegisterTickHandler("idle-timeout", 300, () =>
         {
             foreach (var session in sessions.AllSessions)
             {
+                if (session.PlayerEntity.HasTag(adminTag)) { continue; }
+
                 var idleTicks = _tickCount - session.LastInputTick;
 
                 if (_idleTimeoutTicks > 0 && idleTicks >= _idleTimeoutTicks)
@@ -272,12 +277,12 @@ public class GameLoop
                         Guid.Parse(session.Connection.Id),
                         session.PlayerEntity.Id,
                         "idle timeout"));
-                    session.Connection.SendLine("You have been disconnected for being idle.");
+                    session.Connection.SendLine(timeoutMessage);
                     session.Connection.Disconnect("idle timeout");
                 }
                 else if (_idleWarningTicks > 0 && idleTicks >= _idleWarningTicks && !session.IdleWarned)
                 {
-                    session.Connection.SendLine("You feel drowsy...");
+                    session.Connection.SendLine(warnMessage);
                     session.IdleWarned = true;
                 }
             }

--- a/src/Tapestry.Engine/Room.cs
+++ b/src/Tapestry.Engine/Room.cs
@@ -79,7 +79,10 @@ public class Room
     {
         entity.Container?.RemoveFromContents(entity);
         entity.LocationRoomId = Id;
-        _entities.Add(entity);
+        if (!_entities.Contains(entity))
+        {
+            _entities.Add(entity);
+        }
     }
 
     public void RemoveEntity(Entity entity)

--- a/src/Tapestry.Server/ConnectionHandler.cs
+++ b/src/Tapestry.Server/ConnectionHandler.cs
@@ -106,6 +106,19 @@ public class ConnectionHandler
         var failedAttempts = 0;
         var maxAttempts = _config.Persistence.MaxLoginAttempts;
 
+        var preLoginCts = new CancellationTokenSource();
+        var preLoginTimeoutSec = _config.Idle.PreLoginTimeoutSeconds;
+        if (preLoginTimeoutSec > 0)
+        {
+            _ = Task.Delay(TimeSpan.FromSeconds(preLoginTimeoutSec), preLoginCts.Token)
+                .ContinueWith(_ =>
+                {
+                    connection.SendLine("Connection timed out.");
+                    connection.Disconnect("pre-login timeout");
+                }, TaskContinuationOptions.OnlyOnRanToCompletion);
+            rawConnection.OnDisconnected += () => preLoginCts.Cancel();
+        }
+
         connection.SendLine("");
         connection.SendLine("=== " + _config.Server.Name + " ===");
         connection.SendLine("");
@@ -126,6 +139,8 @@ public class ConnectionHandler
 
         void CompleteLogin(Entity entity)
         {
+            preLoginCts.Cancel();
+
             if (currentHandler != null)
             {
                 connection.OnInput -= currentHandler;
@@ -144,6 +159,13 @@ public class ConnectionHandler
 
             if (spawnRoom != null)
             {
+                // Remove from current room first -- prevents duplicate tracking on session takeover
+                // (when CompleteLogin is called with a live entity already placed in a room)
+                if (entity.LocationRoomId != null)
+                {
+                    var currentRoom = _world.GetRoom(entity.LocationRoomId);
+                    currentRoom?.RemoveEntity(entity);
+                }
                 spawnRoom.AddEntity(entity);
                 _mobAI.PlayerEnteredRoom(spawnRoom.Id);
             }

--- a/src/Tapestry.Server/GameLoopService.cs
+++ b/src/Tapestry.Server/GameLoopService.cs
@@ -73,6 +73,13 @@ public class GameLoopService : IHostedService
                 return;
             }
 
+            // Session takeover: the entity is now owned by a different connection.
+            // The stale disconnect event from the old connection must not tear down the new session.
+            if (Guid.Parse(session.Connection.Id) != evt.SessionId)
+            {
+                return;
+            }
+
             // Snapshot is synchronous (LocationRoomId still set); only the file write is async
             var playerName = session.PlayerEntity.Name;
             _ = _persistence.SavePlayer(session).ContinueWith(
@@ -107,6 +114,14 @@ public class GameLoopService : IHostedService
 
             _logger.LogInformation("Player {Name} disconnected: {Reason}", playerName, evt.Reason);
         };
+
+        var idle = _config.Idle;
+        if (idle.WarnSeconds > 0 || idle.TimeoutSeconds > 0)
+        {
+            _gameLoop.ConfigureIdleTimeout(idle.WarnSeconds, idle.TimeoutSeconds);
+            _gameLoop.RegisterIdleTimeoutHandler(_eventQueue, _sessions,
+                idle.WarnMessage, idle.TimeoutMessage, idle.AdminTag);
+        }
 
         _gameLoop.OnTickComplete += () =>
         {

--- a/tests/Tapestry.Engine.Tests/GameLoopHardeningTests.cs
+++ b/tests/Tapestry.Engine.Tests/GameLoopHardeningTests.cs
@@ -15,7 +15,7 @@ public class GameLoopHardeningTests
         var eventBus = new EventBus();
         var eventQueue = new SystemEventQueue();
         var gameLoop = new GameLoop(
-            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics());
+            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
 
         var order = new List<string>();
 
@@ -54,7 +54,7 @@ public class GameLoopHardeningTests
         var eventBus = new EventBus();
         var eventQueue = new SystemEventQueue();
         var gameLoop = new GameLoop(
-            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics());
+            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
 
         DisconnectEvent? received = null;
         gameLoop.OnDisconnect += (evt) =>
@@ -81,7 +81,7 @@ public class GameLoopHardeningTests
         var eventBus = new EventBus();
         var eventQueue = new SystemEventQueue();
         var gameLoop = new GameLoop(
-            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics());
+            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
 
         var callCount = 0;
         gameLoop.OnDisconnect += (evt) =>
@@ -163,7 +163,7 @@ public class GameLoopHardeningTests
         var eventBus = new EventBus();
         var eventQueue = new SystemEventQueue();
         var gameLoop = new GameLoop(
-            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics());
+            new CommandRouter(registry, sessions), sessions, eventBus, eventQueue, NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
         var world = new World();
 
         // Set up a room with a player entity

--- a/tests/Tapestry.Engine.Tests/GameLoopTests.cs
+++ b/tests/Tapestry.Engine.Tests/GameLoopTests.cs
@@ -61,7 +61,7 @@ public class GameLoopTests
         var registry = new CommandRegistry();
         var sessions = new SessionManager();
         var eventBus = new EventBus();
-        var gameLoop = new GameLoop(new CommandRouter(registry, sessions), sessions, eventBus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics());
+        var gameLoop = new GameLoop(new CommandRouter(registry, sessions), sessions, eventBus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
         var world = new World();
 
         var entity = new Entity("player", "Test");
@@ -96,7 +96,7 @@ public class GameLoopTests
         var registry = new CommandRegistry();
         var sessions = new SessionManager();
         var eventBus = new EventBus();
-        var gameLoop = new GameLoop(new CommandRouter(registry, sessions), sessions, eventBus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics());
+        var gameLoop = new GameLoop(new CommandRouter(registry, sessions), sessions, eventBus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
         var world = new World();
 
         var entity = new Entity("player", "Test");
@@ -123,7 +123,7 @@ public class GameLoopTests
         var registry = new CommandRegistry();
         var sessions = new SessionManager();
         var eventBus = new EventBus();
-        var gameLoop = new GameLoop(new CommandRouter(registry, sessions), sessions, eventBus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics());
+        var gameLoop = new GameLoop(new CommandRouter(registry, sessions), sessions, eventBus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
 
         var entity = new Entity("player", "Test");
         entity.Stats.BaseMaxHp = 100;
@@ -204,7 +204,7 @@ public class GameLoopTests
         var router = new CommandRouter(registry, sessions);
         var world = new World();
         var bus = new EventBus();
-        var loop = new GameLoop(router, sessions, bus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics());
+        var loop = new GameLoop(router, sessions, bus, new SystemEventQueue(), NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
         return (loop, registry, sessions, world);
     }
 

--- a/tests/Tapestry.Engine.Tests/RoomTests.cs
+++ b/tests/Tapestry.Engine.Tests/RoomTests.cs
@@ -39,6 +39,34 @@ public class RoomTests
     }
 
     [Fact]
+    public void Room_AddEntity_DoesNotDuplicate_WhenCalledTwice()
+    {
+        var room = new Room("town:square", "Town Square", "A square.");
+        var player = new Entity("player", "Rand");
+        room.AddEntity(player);
+        room.AddEntity(player);
+        room.Entities.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Room_AddEntity_DoesNotLeakStaleEntry_AfterMoveAndReAdd()
+    {
+        var roomA = new Room("town:inn", "Inn", ".");
+        var roomB = new Room("town:stable", "Stable", ".");
+        var player = new Entity("player", "Rand");
+
+        roomA.AddEntity(player);
+        roomA.AddEntity(player);
+
+        roomA.RemoveEntity(player);
+        roomB.AddEntity(player);
+
+        roomA.Entities.Should().NotContain(player);
+        roomB.Entities.Should().Contain(player);
+        player.LocationRoomId.Should().Be("town:stable");
+    }
+
+    [Fact]
     public void Room_Tags()
     {
         var room = new Room("town:square", "Town Square", "A square.");

--- a/tests/Tapestry.Engine.Tests/Server/ConnectionHandlerLoginPhaseTests.cs
+++ b/tests/Tapestry.Engine.Tests/Server/ConnectionHandlerLoginPhaseTests.cs
@@ -147,7 +147,7 @@ public class ConnectionHandlerLoginPhaseTests
             new CommandRouter(new CommandRegistry(), sessions),
             sessions, new EventBus(), new SystemEventQueue(),
             NullLogger<GameLoop>.Instance,
-            new TapestryMetrics());
+            new TapestryMetrics(), new TickTimer(10));
 
         var mobAI = new MobAIManager(world, eventBus,
             new CombatManager(world, eventBus),

--- a/tests/Tapestry.Scripting.Tests/JintRuntimeTests.cs
+++ b/tests/Tapestry.Scripting.Tests/JintRuntimeTests.cs
@@ -221,7 +221,7 @@ public class JintRuntimeTests
         var gameLoop = new GameLoop(
             new CommandRouter(commandRegistry, sessions),
             sessions, eventBus, new SystemEventQueue(),
-            NullLogger<GameLoop>.Instance, new TapestryMetrics());
+            NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
 
         // Create service classes
         var messaging = new ApiMessaging(world, sessions, new NullGmcpModuleAdapter(), new CommandResponseContext());

--- a/tests/Tapestry.Scripting.Tests/PackLoaderTests.cs
+++ b/tests/Tapestry.Scripting.Tests/PackLoaderTests.cs
@@ -186,7 +186,7 @@ public class PackLoaderTests
         var gameLoop = new GameLoop(
             new CommandRouter(commandRegistry, sessions),
             sessions, eventBus, new SystemEventQueue(),
-            NullLogger<GameLoop>.Instance, new TapestryMetrics());
+            NullLogger<GameLoop>.Instance, new TapestryMetrics(), new TickTimer(10));
         var messaging = new ApiMessaging(world, sessions, new NullGmcpModuleAdapter(), new CommandResponseContext());
         var alignmentManager = new AlignmentManager(world, eventBus, new AlignmentConfig());
         var doorService = new DoorService(world, eventBus);


### PR DESCRIPTION
## Summary

- **Session takeover fix**: Guard `DisconnectEvent` by `SessionId` (connection GUID) so a stale disconnect from the old connection cannot tear down the new session after takeover
- **Idle timeout**: Configurable warn/timeout (admin-exempt via tag), pre-login `CancellationToken` timer, `IdleSection` added to `ServerConfig`; `TickTimer` injected into `GameLoop` so `ConfigureIdleTimeout` uses `SecondsToTicks()` instead of manual ms math
- **`sac` command** (`tapestry-core`): Sacrifice corpses; guards player corpses unless empty; recursive content destruction via `destroyWithContents`; level-based gold reward; room message to bystanders
- **`death.js`**: Stamp `level` on corpse at creation time; gold-on-kill via `gold_min`/`gold_max` mob properties; `killerId` plumbed through `mob.death` event
- **Test fixes**: All `GameLoop` test constructors updated to pass `new TickTimer(10)`

## Test plan

- [x] Build passes (`dotnet build`)
- [x] Unit tests pass (`dotnet test`)
- [ ] Connect, idle 5 min -- warning message fires
- [ ] Idle 10 min -- disconnected
- [ ] Admin-tagged player exempt from idle kick
- [ ] Connect, leave at login screen -- pre-login timeout fires
- [ ] Kill a mob with `gold_min`/`gold_max` -- gold awarded on kill
- [ ] `sac <mob corpse>` -- destroyed, gold rewarded by level, room sees message
- [ ] `sac <player corpse>` with items inside -- blocked
- [ ] `sac <player corpse>` empty -- allowed, no gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)