### PR TITLE
fix: publish killerId in entity.vital.depleted on kill

### DIFF
--- a/src/Tapestry.Engine/Combat/ResolveAutoAttacksPhase.cs
+++ b/src/Tapestry.Engine/Combat/ResolveAutoAttacksPhase.cs
@@ -106,7 +106,11 @@ public class ResolveAutoAttacksPhase : ICombatPhase
                             SourceEntityId = target.Id,
                             RoomId = target.LocationRoomId,
                             SourceEntityName = target.Name,
-                            Data = new Dictionary<string, object?> { ["vital"] = "hp" }
+                            Data = new Dictionary<string, object?>
+                        {
+                            ["vital"] = "hp",
+                            ["killerId"] = attacker.Id.ToString()
+                        }
                         });
                         break;
                     }

--- a/src/Tapestry.Engine/Heartbeat/AbilityResolutionPhase.cs
+++ b/src/Tapestry.Engine/Heartbeat/AbilityResolutionPhase.cs
@@ -302,7 +302,7 @@ public class AbilityResolutionPhase : IPulseHandler
                 Data = new Dictionary<string, object?>
                 {
                     ["vital"] = "hp",
-                    ["attackerId"] = entity.Id.ToString()
+                    ["killerId"] = entity.Id.ToString()
                 }
             });
         }


### PR DESCRIPTION
## Root Cause

`death.js` reads `event.data.killerId` to award gold on kill, but:

- `ResolveAutoAttacksPhase` published no attacker ID at all in the death event
- `AbilityResolutionPhase` published `attackerId` instead of `killerId`

Auto-attacks are the normal kill path, so gold never fired.

## Fix

Both publishers now include `["killerId"] = attacker/entity.Id.ToString()` in the `entity.vital.depleted` event data, matching what `death.js` expects.

## Test plan

- [ ] Kill a mob via normal auto-attack -- gold drops to killer
- [ ] Kill a mob via ability -- gold drops to killer

🤖 Generated with [Claude Code](https://claude.com/claude-code)