### PR TITLE
fix: use world.send not world.sendToPlayer in death.js

### DIFF
--- a/packs/tapestry-core/scripts/mobs/death.js
+++ b/packs/tapestry-core/scripts/mobs/death.js
@@ -49,7 +49,7 @@ tapestry.events.on("entity.vital.depleted", function(event) {
         if (goldDrop > 0) {
             tapestry.currency.addGold(killerId, goldDrop, "mob_kill");
             var coinWord = goldDrop === 1 ? "coin" : "coins";
-            tapestry.world.sendToPlayer(killerId, "You receive " + goldDrop + " gold " + coinWord + ".\r\n");
+            tapestry.world.send(killerId, "You receive " + goldDrop + " gold " + coinWord + ".\r\n");
         }
     }
 


### PR DESCRIPTION
## Root Cause

`tapestry.world.sendToPlayer` is not a registered JS binding -- the correct API is `tapestry.world.send`. Calling an undefined function threw a silent TypeError in Jint mid-event-handler, locking up event processing on the first mob kill that had a `killerId` (introduced in PR #78).

The gold was being awarded (`addGold` succeeded) but the `sendToPlayer` call immediately after caused the handler to fail in a way that left the game loop stuck.

## Fix

One-line change: `tapestry.world.sendToPlayer` → `tapestry.world.send`.

## Test plan

- [ ] Kill a mob with `gold_min`/`gold_max` -- gold awarded, message received, server stays up
- [ ] Kill multiple mobs -- no lockup

🤖 Generated with [Claude Code](https://claude.com/claude-code)