### PR TITLE
feat: story-driven progression - variance, gain_stat, requires_slot, luck formula

### DIFF
--- a/src/Tapestry.Data/ServerConfig.cs
+++ b/src/Tapestry.Data/ServerConfig.cs
@@ -17,6 +17,7 @@ public class ServerConfig
     public TrainingSection Training { get; set; } = new();
     public EconomySection Economy { get; set; } = new();
     public GameSection Game { get; set; } = new();
+    public CombatSection Combat { get; set; } = new();
     public MsspConfig Mssp { get; set; } = new();
     public IdleSection Idle { get; set; } = new();
 
@@ -165,4 +166,9 @@ public class GameSection
     public float DefaultOccupiedModifier { get; set; } = 3.0f;
     public int DefaultResetInterval { get; set; } = 3000;
     public int WeatherRollIntervalHours { get; set; } = 24;
+}
+
+public class CombatSection
+{
+    public double LuckScale { get; set; } = 0.002;
 }

--- a/src/Tapestry.Engine/Abilities/AbilityDefinition.cs
+++ b/src/Tapestry.Engine/Abilities/AbilityDefinition.cs
@@ -24,6 +24,11 @@ public class AbilityDefinition
     public Dictionary<string, object?> Metadata { get; init; } = new();
     public object? Handler { get; set; }
     public AlignmentRange? AlignmentRange { get; init; }
+    public int Variance { get; init; } = 100;
+    public string? GainStat { get; init; }
+    public double GainStatScale { get; init; } = 0.0;
+    public string? RequiresSlot { get; init; }
+    public string? RequiresSlotTag { get; init; }
 }
 
 public class AbilityEffectDefinition

--- a/src/Tapestry.Engine/Abilities/PassiveAbilityProcessor.cs
+++ b/src/Tapestry.Engine/Abilities/PassiveAbilityProcessor.cs
@@ -20,8 +20,11 @@ public class PassiveAbilityProcessor
         }
 
         var definition = _registry.Get(abilityId);
+        var variance = definition?.Variance ?? 100;
         var maxChance = definition?.MaxChance ?? 100;
-        var effectiveChance = (int)(prof.Value * (maxChance / 100.0));
+        var effectiveChance = variance < 100
+            ? (int)(prof.Value * (variance / 100.0))
+            : (int)(prof.Value * (maxChance / 100.0));
         var roll = random.Next(1, 101);
         return roll <= effectiveChance;
     }
@@ -58,7 +61,9 @@ public class PassiveAbilityProcessor
                 continue;
             }
 
-            var effectiveChance = (int)(prof.Value * (passive.MaxChance / 100.0));
+            var effectiveChance = passive.Variance < 100
+                ? (int)(prof.Value * (passive.Variance / 100.0))
+                : (int)(prof.Value * (passive.MaxChance / 100.0));
             var roll = random.Next(1, 101);
 
             if (roll <= effectiveChance)
@@ -82,7 +87,9 @@ public class PassiveAbilityProcessor
                 continue;
             }
 
-            var effectiveChance = (int)(prof.Value * (passive.MaxChance / 100.0));
+            var effectiveChance = passive.Variance < 100
+                ? (int)(prof.Value * (passive.Variance / 100.0))
+                : (int)(prof.Value * (passive.MaxChance / 100.0));
             var roll = random.Next(1, 101);
 
             if (roll <= effectiveChance)

--- a/src/Tapestry.Engine/Abilities/ProficiencyManager.cs
+++ b/src/Tapestry.Engine/Abilities/ProficiencyManager.cs
@@ -112,7 +112,15 @@ public class ProficiencyManager
         var definition = _registry.Get(abilityId);
         if (definition == null) { return; }
 
-        var effectiveChance = definition.ProficiencyGainChance * (1.0 - current.Value / 100.0);
+        var entity = _world.GetEntity(entityId);
+        var gainStatMultiplier = 1.0;
+        if (entity != null && !string.IsNullOrEmpty(definition.GainStat))
+        {
+            var statValue = GetStatByName(entity, definition.GainStat);
+            gainStatMultiplier = 1.0 + (statValue * definition.GainStatScale);
+        }
+
+        var effectiveChance = definition.ProficiencyGainChance * (1.0 - current.Value / 100.0) * gainStatMultiplier;
         if (wasFailure)
         {
             effectiveChance *= definition.FailureProficiencyGainMultiplier;
@@ -141,5 +149,19 @@ public class ProficiencyManager
             }
         }
         return result;
+    }
+
+    private static int GetStatByName(Entity entity, string statName)
+    {
+        return statName.ToLowerInvariant() switch
+        {
+            "strength" => entity.Stats.Strength,
+            "intelligence" => entity.Stats.Intelligence,
+            "wisdom" => entity.Stats.Wisdom,
+            "dexterity" => entity.Stats.Dexterity,
+            "constitution" => entity.Stats.Constitution,
+            "luck" => entity.Stats.Luck,
+            _ => 0
+        };
     }
 }

--- a/src/Tapestry.Engine/Heartbeat/AbilityResolutionPhase.cs
+++ b/src/Tapestry.Engine/Heartbeat/AbilityResolutionPhase.cs
@@ -19,13 +19,18 @@ public class AbilityResolutionPhase : IPulseHandler
 
     private readonly RaceRegistry? _raceRegistry;
     private readonly AlignmentManager? _alignmentManager;
+    private readonly double _luckScale;
 
     public AbilityResolutionPhase() { }
 
-    public AbilityResolutionPhase(RaceRegistry? raceRegistry = null, AlignmentManager? alignmentManager = null)
+    public AbilityResolutionPhase(
+        RaceRegistry? raceRegistry = null,
+        AlignmentManager? alignmentManager = null,
+        double luckScale = 0.002)
     {
         _raceRegistry = raceRegistry;
         _alignmentManager = alignmentManager;
+        _luckScale = luckScale;
     }
 
     private RaceDefinition? GetRaceFor(Entity entity)
@@ -113,6 +118,7 @@ public class AbilityResolutionPhase : IPulseHandler
         Asleep,
         Alignment_Restricted,
         No_Proficiency,
+        Equipment_Required,
         Initiate_Only,
         Invalid_Target,
         Not_In_Combat,
@@ -145,6 +151,20 @@ public class AbilityResolutionPhase : IPulseHandler
         if (!context.ProficiencyManager.HasAbility(entity.Id, definition.Id))
         {
             return ValidationResult.No_Proficiency;
+        }
+
+        // 1b. Slot requirement check
+        if (!string.IsNullOrEmpty(definition.RequiresSlot))
+        {
+            var equipped = entity.GetEquipment(definition.RequiresSlot);
+            if (equipped == null)
+            {
+                return ValidationResult.Equipment_Required;
+            }
+            if (!string.IsNullOrEmpty(definition.RequiresSlotTag) && !equipped.HasTag(definition.RequiresSlotTag))
+            {
+                return ValidationResult.Equipment_Required;
+            }
         }
 
         // 2. Initiate-only check: fizzles if entity is in combat
@@ -233,10 +253,20 @@ public class AbilityResolutionPhase : IPulseHandler
             delays[definition.Id] = context.CurrentPulse + definition.PulseDelay + 1;
         }
 
-        // Proficiency roll (d100 vs proficiency)
+        // Proficiency roll (variance + luck formula)
         var proficiency = context.ProficiencyManager.GetProficiency(entity.Id, definition.Id) ?? 0;
-        var roll = context.Random.Next(1, 101);
-        var hit = roll <= proficiency;
+        bool hit;
+        if (definition.Variance == 0)
+        {
+            hit = true;
+        }
+        else
+        {
+            var luck = entity.Stats.Luck;
+            var hitChance = (proficiency * (definition.Variance / 100.0)) + (luck * _luckScale);
+            var roll = context.Random.Next(1, 101);
+            hit = roll <= hitChance;
+        }
 
         // Resolve target
         var target = ResolveTarget(entity, queued, context);

--- a/src/Tapestry.Scripting/Modules/AbilitiesModule.cs
+++ b/src/Tapestry.Scripting/Modules/AbilitiesModule.cs
@@ -214,6 +214,35 @@ public class AbilitiesModule : IJintApiModule
                     maxChance = (int)(double)maxChanceVal.ToObject()!;
                 }
 
+                var varianceVal = obj.Get("variance");
+                var variance = 100;
+                if (varianceVal.Type == Types.Number)
+                {
+                    variance = (int)(double)varianceVal.ToObject()!;
+                }
+
+                var gainStatVal = obj.Get("gain_stat");
+                string? gainStat = (gainStatVal.Type != Types.Undefined && gainStatVal.Type != Types.Null)
+                    ? gainStatVal.ToString()
+                    : null;
+
+                var gainStatScaleVal = obj.Get("gain_stat_scale");
+                var gainStatScale = 0.0;
+                if (gainStatScaleVal.Type == Types.Number)
+                {
+                    gainStatScale = (double)gainStatScaleVal.ToObject()!;
+                }
+
+                var requiresSlotVal = obj.Get("requires_slot");
+                string? requiresSlot = (requiresSlotVal.Type != Types.Undefined && requiresSlotVal.Type != Types.Null)
+                    ? requiresSlotVal.ToString()
+                    : null;
+
+                var requiresSlotTagVal = obj.Get("requires_slot_tag");
+                string? requiresSlotTag = (requiresSlotTagVal.Type != Types.Undefined && requiresSlotTagVal.Type != Types.Null)
+                    ? requiresSlotTagVal.ToString()
+                    : null;
+
                 AlignmentRange? alignmentRange = null;
                 var alignmentRangeVal = obj.Get("alignment_range");
                 if (alignmentRangeVal.Type != Types.Undefined && alignmentRangeVal.Type != Types.Null
@@ -340,7 +369,12 @@ public class AbilitiesModule : IJintApiModule
                     CanTarget = canTarget,
                     Metadata = metadata,
                     Handler = handlerObj,
-                    AlignmentRange = alignmentRange
+                    AlignmentRange = alignmentRange,
+                    Variance = variance,
+                    GainStat = gainStat,
+                    GainStatScale = gainStatScale,
+                    RequiresSlot = requiresSlot,
+                    RequiresSlotTag = requiresSlotTag
                 };
 
                 _registry.Register(abilityDef);

--- a/tests/Tapestry.Engine.Tests/Abilities/AbilityDefinitionTests.cs
+++ b/tests/Tapestry.Engine.Tests/Abilities/AbilityDefinitionTests.cs
@@ -84,4 +84,39 @@ public class AbilityDefinitionTests
         var def = new AbilityDefinition { Id = "kick", Name = "Kick" };
         Assert.Equal(0.25, def.FailureProficiencyGainMultiplier);
     }
+
+    [Fact]
+    public void Variance_DefaultsToHundred()
+    {
+        var def = new AbilityDefinition { Id = "kick", Name = "Kick" };
+        Assert.Equal(100, def.Variance);
+    }
+
+    [Fact]
+    public void GainStat_DefaultsToNull()
+    {
+        var def = new AbilityDefinition { Id = "kick", Name = "Kick" };
+        Assert.Null(def.GainStat);
+    }
+
+    [Fact]
+    public void GainStatScale_DefaultsToZero()
+    {
+        var def = new AbilityDefinition { Id = "kick", Name = "Kick" };
+        Assert.Equal(0.0, def.GainStatScale);
+    }
+
+    [Fact]
+    public void RequiresSlot_DefaultsToNull()
+    {
+        var def = new AbilityDefinition { Id = "kick", Name = "Kick" };
+        Assert.Null(def.RequiresSlot);
+    }
+
+    [Fact]
+    public void RequiresSlotTag_DefaultsToNull()
+    {
+        var def = new AbilityDefinition { Id = "kick", Name = "Kick" };
+        Assert.Null(def.RequiresSlotTag);
+    }
 }

--- a/tests/Tapestry.Engine.Tests/Abilities/PassiveAbilityProcessorTests.cs
+++ b/tests/Tapestry.Engine.Tests/Abilities/PassiveAbilityProcessorTests.cs
@@ -205,4 +205,34 @@ public class PassiveAbilityProcessorTests
         var rate = (double)successes / trials;
         Assert.InRange(rate, 0.25, 0.35); // ~30%, not ~40%
     }
+
+    [Fact]
+    public void CheckBinaryPassive_Variance50_FiresAtHalfRateVsMaxChance100()
+    {
+        Setup();
+        _registry.Register(new AbilityDefinition
+        {
+            Id = "lf:parry",
+            Name = "Parry",
+            Type = AbilityType.Passive,
+            Category = AbilityCategory.Skill,
+            Variance = 50,
+            MaxChance = 100,
+            Metadata = new Dictionary<string, object?> { ["passive_mode"] = "binary", ["hook"] = "defensive_check" }
+        });
+        _proficiency.Learn(_player.Id, "lf:parry", 100);
+        var processor = new PassiveAbilityProcessor(_registry, _proficiency);
+
+        var hitCount = 0;
+        var random = new Random(42);
+        for (var i = 0; i < 200; i++)
+        {
+            if (processor.CheckBinaryPassive(_player.Id, "lf:parry", random))
+            {
+                hitCount++;
+            }
+        }
+        // ~50% hit rate -- not 100%. Allow 60-140 out of 200.
+        Assert.InRange(hitCount, 60, 140);
+    }
 }

--- a/tests/Tapestry.Engine.Tests/Abilities/ProficiencyManagerTests.cs
+++ b/tests/Tapestry.Engine.Tests/Abilities/ProficiencyManagerTests.cs
@@ -242,4 +242,74 @@ public class ProficiencyManagerTests
         Assert.Contains(learned, l => l.AbilityId == "kick" && l.Proficiency == 1);
         Assert.Contains(learned, l => l.AbilityId == "fireball" && l.Proficiency == 50);
     }
+
+    [Fact]
+    public void RollProficiencyGain_WithGainStat_MultipliesChanceByStatBonus()
+    {
+        Setup();
+        _registry.Register(new AbilityDefinition
+        {
+            Id = "wisdom_ability",
+            Name = "Wisdom Ability",
+            ProficiencyGainChance = 1.0,  // 100% base chance
+            GainStat = "wisdom",
+            GainStatScale = 0.1           // +10% per wisdom point
+        });
+
+        _player.Stats.BaseWisdom = 10;
+        _proficiency.Learn(_player.Id, "wisdom_ability", 50);
+        _proficiency.SetCap(_player.Id, "wisdom_ability", 100);
+
+        // effectiveChance = 1.0 * (1 - 50/100) * (1 + 10 * 0.1) = 0.5 * 2.0 = 1.0
+        // Should always gain
+        var gainCount = 0;
+        for (var i = 0; i < 20; i++)
+        {
+            var before = _proficiency.GetProficiency(_player.Id, "wisdom_ability")!.Value;
+            _proficiency.RollProficiencyGain(_player.Id, "wisdom_ability", new Random(i));
+            var after = _proficiency.GetProficiency(_player.Id, "wisdom_ability")!.Value;
+            if (after > before)
+            {
+                gainCount++;
+            }
+            _proficiency.SetProficiency(_player.Id, "wisdom_ability", 50); // reset
+        }
+
+        // With 100% effective chance, should gain every time
+        Assert.Equal(20, gainCount);
+    }
+
+    [Fact]
+    public void RollProficiencyGain_WithNullGainStat_BehavesLikeCurrentFormula()
+    {
+        Setup();
+        _registry.Register(new AbilityDefinition
+        {
+            Id = "no_stat_ability",
+            Name = "No Stat Ability",
+            ProficiencyGainChance = 1.0,
+            GainStat = null,
+            GainStatScale = 0.0
+        });
+
+        _proficiency.Learn(_player.Id, "no_stat_ability", 50);
+        _proficiency.SetCap(_player.Id, "no_stat_ability", 100);
+
+        // effectiveChance = 1.0 * (1 - 50/100) * 1.0 = 0.5
+        var gainCount = 0;
+        for (var i = 0; i < 100; i++)
+        {
+            var before = _proficiency.GetProficiency(_player.Id, "no_stat_ability")!.Value;
+            _proficiency.RollProficiencyGain(_player.Id, "no_stat_ability", new Random(i));
+            var after = _proficiency.GetProficiency(_player.Id, "no_stat_ability")!.Value;
+            if (after > before)
+            {
+                gainCount++;
+            }
+            _proficiency.SetProficiency(_player.Id, "no_stat_ability", 50);
+        }
+
+        // ~50% gain rate -- expect between 30 and 70
+        Assert.InRange(gainCount, 30, 70);
+    }
 }

--- a/tests/Tapestry.Engine.Tests/Heartbeat/AbilityResolutionPhaseTests.cs
+++ b/tests/Tapestry.Engine.Tests/Heartbeat/AbilityResolutionPhaseTests.cs
@@ -398,4 +398,123 @@ public class AbilityResolutionPhaseTests
         // Queue cleared
         Assert.False(player.HasProperty(AbilityProperties.QueuedActions));
     }
+
+    [Fact]
+    public void Resolve_Variance0_AlwaysHitsRegardlessOfLowProficiency()
+    {
+        Setup();
+        var player = CreatePlayer("Alice", 100, 100);
+        var mob = CreateMob("Trolloc", 50);
+        _combatManager.Engage(player, mob);
+
+        _abilityRegistry.Register(new AbilityDefinition
+        {
+            Id = "test_zero_variance",
+            Name = "Test Zero Variance",
+            Category = AbilityCategory.Skill,
+            Variance = 0,
+            ProficiencyGainChance = 0.0
+        });
+
+        _proficiencyManager.Learn(player.Id, "test_zero_variance", 1);
+
+        // Run 20 times -- all should hit (ability.used), never miss
+        for (var i = 0; i < 20; i++)
+        {
+            _events.Clear();
+            player.SetProperty("queued_actions", new List<object>
+            {
+                new Dictionary<string, object?> { ["abilityId"] = "test_zero_variance" }
+            });
+            _phase.Execute(MakeContext(i + 1));
+        }
+
+        Assert.DoesNotContain(_events, e => e.Type == "ability.missed");
+    }
+
+    [Fact]
+    public void Resolve_Variance50_HalfProficiencyChance()
+    {
+        Setup();
+        var player = CreatePlayer("Bob", 100, 100);
+        player.Stats.BaseLuck = 0;
+        var mob = CreateMob("Trolloc", 5000);
+        _combatManager.Engage(player, mob);
+
+        _abilityRegistry.Register(new AbilityDefinition
+        {
+            Id = "test_half_variance",
+            Name = "Test Half Variance",
+            Category = AbilityCategory.Skill,
+            Variance = 50,
+            ProficiencyGainChance = 0.0
+        });
+
+        _proficiencyManager.Learn(player.Id, "test_half_variance", 100);
+
+        // proficiency=100, variance=50, luck=0 -> hitChance=50
+        _events.Clear();
+        player.SetProperty("queued_actions", new List<object>
+        {
+            new Dictionary<string, object?> { ["abilityId"] = "test_half_variance" }
+        });
+        _phase.Execute(MakeContext(1));
+
+        // Either ability.used or ability.missed - just verify it resolves without error
+        Assert.True(_events.Any(e => e.Type == "ability.used" || e.Type == "ability.missed"));
+    }
+
+    [Fact]
+    public void Resolve_LuckBonus_IncreasesHitChance()
+    {
+        Setup();
+        var phase = new AbilityResolutionPhase(luckScale: 1.0); // luck=1 = +1% per luck point
+
+        var player = CreatePlayer("Charlie", 100, 100);
+        player.Stats.BaseLuck = 0;
+        var mob = CreateMob("Trolloc", 5000);
+        _combatManager.Engage(player, mob);
+
+        _abilityRegistry.Register(new AbilityDefinition
+        {
+            Id = "test_luck_ability",
+            Name = "Test Luck",
+            Category = AbilityCategory.Skill,
+            Variance = 100,
+            ProficiencyGainChance = 0.0
+        });
+
+        _proficiencyManager.Learn(player.Id, "test_luck_ability", 0);
+        _proficiencyManager.SetProficiency(player.Id, "test_luck_ability", 1);
+
+        // With proficiency=1, variance=100, luck=0: hitChance=1 -> very low hit rate
+        var hitCount = 0;
+        for (var i = 0; i < 100; i++)
+        {
+            player.SetProperty("queued_actions", new List<object>
+            {
+                new Dictionary<string, object?> { ["abilityId"] = "test_luck_ability" }
+            });
+            var ctx = new PulseContext
+            {
+                CurrentTick = i + 1,
+                CurrentPulse = i + 1,
+                World = _world,
+                EventBus = _eventBus,
+                CombatManager = _combatManager,
+                AbilityRegistry = _abilityRegistry,
+                ProficiencyManager = _proficiencyManager,
+                EffectManager = _effectManager,
+                SessionManager = _sessionManager,
+                AlignmentManager = new Tapestry.Engine.Alignment.AlignmentManager(_world, _eventBus, new Tapestry.Engine.Alignment.AlignmentConfig()),
+                Random = new Random(i + 100)
+            };
+            phase.Execute(ctx);
+            if (_events.Any(e => e.Type == "ability.used")) { hitCount++; }
+            _events.Clear();
+        }
+
+        // With hitChance=1, expect roughly 1% hit rate -- definitely < 10 out of 100
+        Assert.True(hitCount < 10, $"Expected <10 hits with hitChance=1, got {hitCount}");
+    }
 }

--- a/tests/Tapestry.Engine.Tests/Heartbeat/AbilityResolutionPhaseTests.cs
+++ b/tests/Tapestry.Engine.Tests/Heartbeat/AbilityResolutionPhaseTests.cs
@@ -445,23 +445,43 @@ public class AbilityResolutionPhaseTests
         {
             Id = "test_half_variance",
             Name = "Test Half Variance",
+            Type = AbilityType.Active,
             Category = AbilityCategory.Skill,
             Variance = 50,
-            ProficiencyGainChance = 0.0
+            ProficiencyGainChance = 0.0,
+            MaxChance = 100
         });
 
         _proficiencyManager.Learn(player.Id, "test_half_variance", 100);
 
-        // proficiency=100, variance=50, luck=0 -> hitChance=50
-        _events.Clear();
-        player.SetProperty("queued_actions", new List<object>
+        // proficiency=100, variance=50, luck=0 -> hitChance=50 -> ~50% hit rate
+        var hitCount = 0;
+        for (var i = 0; i < 200; i++)
         {
-            new Dictionary<string, object?> { ["abilityId"] = "test_half_variance" }
-        });
-        _phase.Execute(MakeContext(1));
+            _events.Clear();
+            QueueAbility(player, "test_half_variance");
 
-        // Either ability.used or ability.missed - just verify it resolves without error
-        Assert.True(_events.Any(e => e.Type == "ability.used" || e.Type == "ability.missed"));
+            // Create context with varied seed for each iteration
+            var ctx = new PulseContext
+            {
+                CurrentTick = i + 1,
+                CurrentPulse = i + 1,
+                World = _world,
+                EventBus = _eventBus,
+                CombatManager = _combatManager,
+                AbilityRegistry = _abilityRegistry,
+                ProficiencyManager = _proficiencyManager,
+                EffectManager = _effectManager,
+                SessionManager = _sessionManager,
+                Random = new Random(i + 1000)
+            };
+            _phase.Execute(ctx);
+
+            if (_events.Any(e => e.Type == "ability.used")) { hitCount++; }
+        }
+
+        // ~50% hit rate -- allow 60-140 out of 200
+        Assert.InRange(hitCount, 60, 140);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds `Variance`, `GainStat`, `GainStatScale`, `RequiresSlot`, `RequiresSlotTag` to `AbilityDefinition` to support stat-scaling, equipment-gated, and always-firing abilities
- Updates hit formula in `AbilityResolutionPhase`: `Variance==0` always fires; otherwise `hitChance = proficiency * (variance/100) + luck * luckScale`
- Updates `ProficiencyManager.RollProficiencyGain` to apply a stat multiplier based on `GainStat`/`GainStatScale`
- Updates `PassiveAbilityProcessor` to use `Variance` when `< 100`, falling back to `MaxChance`
- Adds `CombatSection` with `LuckScale` to `ServerConfig`
- Wires all five new fields through `AbilitiesModule` for JS scripting

## Test Plan

- [ ] 905 engine tests pass (`dotnet test tests/Tapestry.Engine.Tests/`)
- [ ] Variance=0 always-hit test (20/20 hits at proficiency 1)
- [ ] Variance=50 ~50% hit rate test (60-140 out of 200 with varied seeds)
- [ ] Luck bonus hit chance test (< 10 hits with hitChance=1 over 100 rolls)
- [ ] GainStat multiplier test (always gains at proficiency 50 with wisdom=10, scale=0.1)
- [ ] Passive Variance=50 test (60-140 fires out of 200)
- [ ] Equipment_Required blocks ability when required slot empty

Generated with [Claude Code](https://claude.com/claude-code)