### PR TITLE
Unify quest script execution into PackLoader (one loader)

### DIFF
--- a/src/Tapestry.Scripting/JintRuntime.cs
+++ b/src/Tapestry.Scripting/JintRuntime.cs
@@ -54,7 +54,10 @@ public class JintRuntime
     }
 
     /// <summary>
-    /// Execute a script without a pack name. Convenience for tests.
+    /// Execute a script without setting pack/source attribution. TESTS ONLY -- do NOT use for
+    /// pack execution: it leaves __currentPack/__currentSource at their prior values, so any
+    /// registration (e.g. registerScript) records a stale/blank owner. Pack content must run
+    /// through the attributed Execute(script, packName, sourceFile) overload (the scripts: glob).
     /// </summary>
     public void Execute(string script)
     {

--- a/src/Tapestry.Scripting/JintRuntime.cs
+++ b/src/Tapestry.Scripting/JintRuntime.cs
@@ -62,10 +62,19 @@ public class JintRuntime
     }
 
     /// <summary>
-    /// Records that a script file (by absolute path) has been executed this boot. Returns true
-    /// the first time a path is seen, false if it was already executed -- the caller skips the
-    /// second run. Path is normalised so glob-relative and quest-script-relative forms of the
-    /// same file collapse to one key.
+    /// Records that a script file (by absolute path) was executed this boot, building the
+    /// ledger of which files the pack <c>scripts:</c> glob loaded. Path is normalised
+    /// (<see cref="Path.GetFullPath(string)"/>) so glob-relative and other forms of the same
+    /// file collapse to one key.
+    ///
+    /// CONSUMER: QuestStartupModule's quest-script coverage assertion
+    /// (QuestScriptCoverageVerifier) reads this ledger via <see cref="HasExecutedFile"/> to
+    /// confirm every quest <c>script:</c> was actually loaded by the glob. Do not remove the
+    /// glob's call to this method as "dead" -- that coverage check depends on it.
+    ///
+    /// The bool return (true on first sight, false on repeat) is currently unused by every
+    /// caller; it is kept to preserve the idempotence/path-normalisation contract pinned by
+    /// JintRuntimeTests.MarkFileExecuted_IsIdempotent_AndPathNormalized.
     /// </summary>
     public bool MarkFileExecuted(string absolutePath)
     {

--- a/src/Tapestry.Scripting/Modules/QuestScriptLoader.cs
+++ b/src/Tapestry.Scripting/Modules/QuestScriptLoader.cs
@@ -64,6 +64,15 @@ public class QuestScriptLoader : IQuestScriptLoader
         return _scripts.ContainsKey(questId);
     }
 
+    /// <summary>
+    /// Test/diagnostic accessor: the owning pack recorded for a quest's hooks, or null if
+    /// no hooks are registered for the quest. Pins that hooks bind under their real owner.
+    /// </summary>
+    internal string? OwnerOf(string questId)
+    {
+        return _scripts.TryGetValue(questId, out var hooks) ? hooks.Pack : null;
+    }
+
     public bool CallOnGranted(string questId, Guid playerId)
     {
         if (!_scripts.TryGetValue(questId, out var hooks) || hooks.OnGranted == null || JintEngine == null)

--- a/src/Tapestry.Scripting/Modules/QuestScriptLoader.cs
+++ b/src/Tapestry.Scripting/Modules/QuestScriptLoader.cs
@@ -65,8 +65,10 @@ public class QuestScriptLoader : IQuestScriptLoader
     }
 
     /// <summary>
-    /// Test/diagnostic accessor: the owning pack recorded for a quest's hooks, or null if
-    /// no hooks are registered for the quest. Pins that hooks bind under their real owner.
+    /// Test/diagnostic accessor: the pack owner recorded for a quest's hooks. Returns null
+    /// only when no hooks are registered for the quest; returns the recorded owner otherwise,
+    /// which may be the empty string if the hooks were registered with no owner (the blank-owner
+    /// case this accessor exists to surface). Do not collapse empty-to-null -- that would hide it.
     /// </summary>
     internal string? OwnerOf(string questId)
     {

--- a/src/Tapestry.Server/Modules/QuestScriptCoverageVerifier.cs
+++ b/src/Tapestry.Server/Modules/QuestScriptCoverageVerifier.cs
@@ -8,9 +8,10 @@ namespace Tapestry.Server.Modules;
 /// <summary>
 /// Asserts that every quest carrying a <c>script:</c> field references a JS file that the
 /// pack <c>scripts:</c> glob actually loaded. The glob is the single quest-script executor;
-/// a <c>script:</c> naming an unloaded file means its hooks can never bind. This is a
-/// per-pack content check: a strict pack (the default) fails the boot; a
-/// <c>validation: lenient</c> pack only warns -- the same convention as PackValidator.
+/// a <c>script:</c> naming a file that is missing on disk or simply never loaded by the glob
+/// means its hooks can never bind. This is a per-pack content check: a strict pack (the
+/// default) fails the boot; a <c>validation: lenient</c> pack only warns -- the same
+/// convention as PackValidator.
 /// </summary>
 public class QuestScriptCoverageVerifier
 {
@@ -35,25 +36,29 @@ public class QuestScriptCoverageVerifier
     {
         foreach (var quest in _questRegistry.All().Where(q => q.Script != null && q.PackDirectory != null))
         {
-            var scriptPath = Path.Combine(quest.PackDirectory!, quest.Script!);
+            // Rooted/normalized so File.Exists and the ledger lookup are unambiguous.
+            var scriptPath = Path.GetFullPath(Path.Combine(quest.PackDirectory!, quest.Script!));
 
-            if (!File.Exists(scriptPath))
+            var missing = !File.Exists(scriptPath);
+            var unglobbed = !missing && !_runtime.HasExecutedFile(scriptPath);
+
+            if (!missing && !unglobbed)
             {
-                _logger.LogWarning("Quest script not found: {Path}", scriptPath);
-                continue;
+                continue; // exists and the scripts glob already loaded it with correct attribution
             }
 
-            if (_runtime.HasExecutedFile(scriptPath))
-            {
-                continue; // the scripts glob already loaded it with correct attribution
-            }
-
+            // A missing file is a typo'd script: path -- a guaranteed dead hook, the exact
+            // silent failure this check exists to prevent -- so it is gated identically to an
+            // unglobbed file, not merely warned.
             var owner = OwnerManifest(quest.PackDirectory!);
             var ownerName = owner?.Name ?? "(unknown)";
+            var reason = missing
+                ? $"the file '{scriptPath}' does not exist"
+                : $"'{scriptPath}' was not loaded by the pack's scripts: glob";
             var message =
                 $"Quest '{quest.Id}' (pack '{ownerName}') declares script '{quest.Script}', but " +
-                $"'{scriptPath}' was not loaded by the pack's scripts: glob; its hooks can never bind. " +
-                "Move the file under the scripts: glob -- it is the only quest-script loader.";
+                $"{reason}; its hooks can never bind. " +
+                "Place the file under the scripts: glob -- it is the only quest-script loader.";
 
             if (owner?.Validation == "lenient")
             {

--- a/src/Tapestry.Server/Modules/QuestScriptCoverageVerifier.cs
+++ b/src/Tapestry.Server/Modules/QuestScriptCoverageVerifier.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using Tapestry.Engine.Quests;
+using Tapestry.Scripting;
+using Tapestry.Shared;
+
+namespace Tapestry.Server.Modules;
+
+/// <summary>
+/// Asserts that every quest carrying a <c>script:</c> field references a JS file that the
+/// pack <c>scripts:</c> glob actually loaded. The glob is the single quest-script executor;
+/// a <c>script:</c> naming an unloaded file means its hooks can never bind. This is a
+/// per-pack content check: a strict pack (the default) fails the boot; a
+/// <c>validation: lenient</c> pack only warns -- the same convention as PackValidator.
+/// </summary>
+public class QuestScriptCoverageVerifier
+{
+    private readonly QuestRegistry _questRegistry;
+    private readonly JintRuntime _runtime;
+    private readonly IPackManifestProvider _manifestProvider;
+    private readonly ILogger<QuestScriptCoverageVerifier> _logger;
+
+    public QuestScriptCoverageVerifier(
+        QuestRegistry questRegistry,
+        JintRuntime runtime,
+        IPackManifestProvider manifestProvider,
+        ILogger<QuestScriptCoverageVerifier> logger)
+    {
+        _questRegistry = questRegistry;
+        _runtime = runtime;
+        _manifestProvider = manifestProvider;
+        _logger = logger;
+    }
+
+    public void Verify()
+    {
+        foreach (var quest in _questRegistry.All().Where(q => q.Script != null && q.PackDirectory != null))
+        {
+            var scriptPath = Path.Combine(quest.PackDirectory!, quest.Script!);
+
+            if (!File.Exists(scriptPath))
+            {
+                _logger.LogWarning("Quest script not found: {Path}", scriptPath);
+                continue;
+            }
+
+            if (_runtime.HasExecutedFile(scriptPath))
+            {
+                continue; // the scripts glob already loaded it with correct attribution
+            }
+
+            var owner = OwnerManifest(quest.PackDirectory!);
+            var ownerName = owner?.Name ?? "(unknown)";
+            var message =
+                $"Quest '{quest.Id}' (pack '{ownerName}') declares script '{quest.Script}', but " +
+                $"'{scriptPath}' was not loaded by the pack's scripts: glob; its hooks can never bind. " +
+                "Move the file under the scripts: glob -- it is the only quest-script loader.";
+
+            if (owner?.Validation == "lenient")
+            {
+                _logger.LogWarning("{Message}", message);
+            }
+            else
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+
+    private PackManifest? OwnerManifest(string packDirectory)
+    {
+        var full = Path.GetFullPath(packDirectory);
+        return _manifestProvider.LoadedPacks.FirstOrDefault(m =>
+            !string.IsNullOrEmpty(m.PackDirectory) && Path.GetFullPath(m.PackDirectory) == full);
+    }
+}

--- a/src/Tapestry.Server/Modules/QuestStartupModule.cs
+++ b/src/Tapestry.Server/Modules/QuestStartupModule.cs
@@ -1,72 +1,36 @@
-using Microsoft.Extensions.Logging;
 using Tapestry.Contracts;
 using Tapestry.Engine.Quests;
-using Tapestry.Scripting;
 
 namespace Tapestry.Server.Modules;
 
 public class QuestStartupModule : IGameModule
 {
-    private readonly QuestRegistry _questRegistry;
     private readonly QuestObjectiveWatcher _objectiveWatcher;
-    private readonly JintRuntime _jintRuntime;
     private readonly QuestPersistenceService _persistenceService;
-    private readonly ILogger<QuestStartupModule> _logger;
+    private readonly QuestScriptCoverageVerifier _coverageVerifier;
 
     public string Name => "QuestStartup";
 
     public QuestStartupModule(
-        QuestRegistry questRegistry,
         QuestObjectiveWatcher objectiveWatcher,
-        JintRuntime jintRuntime,
         QuestPersistenceService persistenceService,
-        ILogger<QuestStartupModule> logger)
+        QuestScriptCoverageVerifier coverageVerifier)
     {
-        _questRegistry = questRegistry;
         _objectiveWatcher = objectiveWatcher;
-        _jintRuntime = jintRuntime;
         _persistenceService = persistenceService;
-        _logger = logger;
+        _coverageVerifier = coverageVerifier;
     }
 
     public void Configure()
     {
-        // Quests are loaded by PackLoader.LoadContent via the quests: glob in each pack manifest.
-        // Here we only load the JS lifecycle scripts and start persistence.
+        // Quests are loaded by PackLoader.LoadContent via the quests: glob. Quest JS lifecycle
+        // scripts are loaded by the SINGLE executor -- the pack scripts: glob (also PackLoader),
+        // with full pack/source attribution. The legacy quest `script:` field no longer drives
+        // loading; here we only assert each declared script: was actually loaded by the glob
+        // (a strict pack fails the boot, a lenient pack warns), then start persistence + watcher.
+        _coverageVerifier.Verify();
 
-        // Load quest lifecycle scripts
-        foreach (var quest in _questRegistry.All().Where(q => q.Script != null && q.PackDirectory != null))
-        {
-            var scriptPath = Path.Combine(quest.PackDirectory!, quest.Script!);
-            if (!File.Exists(scriptPath))
-            {
-                _logger.LogWarning("Quest script not found: {Path}", scriptPath);
-                continue;
-            }
-
-            // The pack `scripts:` glob may already have executed this file (quest scripts
-            // routinely live under scripts/). Running it again re-fires registerScript and,
-            // under the RegistrationPolicy, trips a same-pack quest-hook collision. Skip any
-            // file already executed; MarkFileExecuted returns false when that's the case.
-            if (!_jintRuntime.MarkFileExecuted(scriptPath))
-            {
-                _logger.LogDebug("Quest script already loaded by the scripts glob, skipping: {Path}", scriptPath);
-                continue;
-            }
-
-            try
-            {
-                _jintRuntime.Execute(File.ReadAllText(scriptPath));
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to load quest script: {Path}", scriptPath);
-            }
-        }
-
-        // Start persistence (subscribes to player.login)
         _persistenceService.Start();
-
         _objectiveWatcher.Start();
     }
 }

--- a/src/Tapestry.Server/Modules/QuestStartupModule.cs
+++ b/src/Tapestry.Server/Modules/QuestStartupModule.cs
@@ -26,10 +26,15 @@ public class QuestStartupModule : IGameModule
         // Quests are loaded by PackLoader.LoadContent via the quests: glob. Quest JS lifecycle
         // scripts are loaded by the SINGLE executor -- the pack scripts: glob (also PackLoader),
         // with full pack/source attribution. The legacy quest `script:` field no longer drives
-        // loading; here we only assert each declared script: was actually loaded by the glob
-        // (a strict pack fails the boot, a lenient pack warns), then start persistence + watcher.
+        // loading; here we only assert each declared script: was actually loaded by the glob.
+        //
+        // Fail-fast tradeoff: the old executor swallowed script exceptions and always reached
+        // the Start() calls below. Verify() instead THROWS on a strict pack whose script: can
+        // never bind -- halting boot rather than starting a degraded quest system. Deliberate:
+        // a quest whose hooks can never fire is worse than a clean boot failure.
         _coverageVerifier.Verify();
 
+        // Start persistence (subscribes to player.login), then the objective watcher.
         _persistenceService.Start();
         _objectiveWatcher.Start();
     }

--- a/src/Tapestry.Server/Program.cs
+++ b/src/Tapestry.Server/Program.cs
@@ -163,6 +163,7 @@ builder.Services.AddSingleton<Tapestry.Server.Gmcp.Handlers.LoginHandler>();
 // Game modules -- order is boot order
 builder.Services.AddSingleton<IGameModule, ConfigurationModule>();
 builder.Services.AddSingleton<IGameModule, ContentLoadingModule>();
+builder.Services.AddSingleton<QuestScriptCoverageVerifier>();
 builder.Services.AddSingleton<IGameModule, QuestStartupModule>();
 builder.Services.AddSingleton<IGameModule, CombatEventModule>();
 builder.Services.AddSingleton<IGameModule, WorldEventModule>();

--- a/tests/Tapestry.Scripting.Tests/Modules/QuestHookOverrideTests.cs
+++ b/tests/Tapestry.Scripting.Tests/Modules/QuestHookOverrideTests.cs
@@ -80,4 +80,15 @@ public class QuestHookOverrideTests
         rt.Execute(IntroBOverride, "pack-b", "scripts/b.js");
         Assert.Throws<InvalidOperationException>(() => policy.Resolve());
     }
+
+    [Fact]
+    public void RegisterScript_ViaGlobPath_RecordsRealOwner()
+    {
+        var (rt, policy, loader, _) = BuildRuntime();
+        rt.Execute(Intro, "pack-a", "scripts/quests/intro.js");
+        policy.Resolve();
+
+        loader.OwnerOf("quest:intro").Should().Be("pack-a",
+            "hooks executed through the attributed glob path must bind under their real owning pack");
+    }
 }

--- a/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
+++ b/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
@@ -77,4 +77,30 @@ public class QuestScriptCoverageVerifierTests : IDisposable
         var ex = Assert.Throws<InvalidOperationException>(() => verifier.Verify());
         ex.Message.Should().Contain("q1").And.Contain("@test/pack").And.Contain("quests/q1.js");
     }
+
+    [Fact]
+    public void MissingScript_StrictPack_Throws()
+    {
+        // No file written -- the script: path does not exist (typo'd path = dead hook).
+        var quests = new QuestRegistry();
+        quests.Register(new QuestDefinition { Id = "q1", Script = "quests/nope.js", PackDirectory = _packDir });
+        var rt = BuildRuntime();
+        var verifier = BuildVerifier(quests, rt, validation: "strict");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => verifier.Verify());
+        ex.Message.Should().Contain("q1").And.Contain("does not exist");
+    }
+
+    [Fact]
+    public void MissingScript_LenientPack_DoesNotThrow()
+    {
+        // No file written; lenient pack warns instead of failing the boot.
+        var quests = new QuestRegistry();
+        quests.Register(new QuestDefinition { Id = "q1", Script = "quests/nope.js", PackDirectory = _packDir });
+        var rt = BuildRuntime();
+        var verifier = BuildVerifier(quests, rt, validation: "lenient");
+
+        var act = () => verifier.Verify();
+        act.Should().NotThrow("a validation: lenient pack warns on a missing script: instead of failing the boot");
+    }
 }

--- a/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
+++ b/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Tapestry.Engine;
+using Tapestry.Engine.Quests;
+using Tapestry.Scripting;
+using Tapestry.Scripting.Interop;
+using Tapestry.Server.Modules;
+using Tapestry.Shared;
+using Xunit;
+
+namespace Tapestry.Server.Tests.Modules;
+
+public class QuestScriptCoverageVerifierTests : IDisposable
+{
+    private readonly string _packDir;
+
+    public QuestScriptCoverageVerifierTests()
+    {
+        _packDir = Path.Combine(Path.GetTempPath(), "qscv-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_packDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_packDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private sealed class FakeManifests : IPackManifestProvider
+    {
+        public IReadOnlyList<PackManifest> LoadedPacks { get; init; } = new List<PackManifest>();
+    }
+
+    private static JintRuntime BuildRuntime()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTapestryEngine();
+        services.AddTapestryScripting();
+        var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<PackDependencyGraph>().Build(new Dictionary<string, List<string>>());
+        var rt = provider.GetRequiredService<JintRuntime>();
+        rt.Initialize();
+        return rt;
+    }
+
+    private string WriteScriptFile(string relative)
+    {
+        var path = Path.Combine(_packDir, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "// quest script");
+        return path;
+    }
+
+    private QuestScriptCoverageVerifier BuildVerifier(QuestRegistry quests, JintRuntime rt, string validation)
+    {
+        var manifests = new FakeManifests
+        {
+            LoadedPacks = new List<PackManifest>
+            {
+                new() { Name = "@test/pack", PackDirectory = _packDir, Validation = validation },
+            },
+        };
+        return new QuestScriptCoverageVerifier(quests, rt, manifests,
+            NullLogger<QuestScriptCoverageVerifier>.Instance);
+    }
+
+    [Fact]
+    public void UncoveredScript_StrictPack_Throws_NamingQuestPackAndPath()
+    {
+        WriteScriptFile("quests/q1.js"); // exists on disk, but NOT marked executed by the glob
+        var quests = new QuestRegistry();
+        quests.Register(new QuestDefinition { Id = "q1", Script = "quests/q1.js", PackDirectory = _packDir });
+        var rt = BuildRuntime();
+        var verifier = BuildVerifier(quests, rt, validation: "strict");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => verifier.Verify());
+        ex.Message.Should().Contain("q1").And.Contain("@test/pack").And.Contain("quests/q1.js");
+    }
+}

--- a/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
+++ b/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
@@ -131,4 +131,27 @@ public class QuestScriptCoverageVerifierTests : IDisposable
         var act = () => verifier.Verify();
         act.Should().NotThrow("the glob already loaded the file -- this is the trolloc-slayer shape");
     }
+
+    [Fact]
+    public void UncoveredScript_NoMatchingManifest_DefaultsToStrict_Throws()
+    {
+        WriteScriptFile("quests/q1.js"); // exists on disk, not marked executed
+        var quests = new QuestRegistry();
+        quests.Register(new QuestDefinition { Id = "q1", Script = "quests/q1.js", PackDirectory = _packDir });
+        var rt = BuildRuntime();
+
+        // No manifest matches _packDir -> owner resolves to null -> defaults to strict (throw).
+        var manifests = new FakeManifests
+        {
+            LoadedPacks = new List<PackManifest>
+            {
+                new() { Name = "@other/pack", PackDirectory = Path.Combine(Path.GetTempPath(), "some-other-dir"), Validation = "lenient" },
+            },
+        };
+        var verifier = new QuestScriptCoverageVerifier(quests, rt, manifests,
+            NullLogger<QuestScriptCoverageVerifier>.Instance);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => verifier.Verify());
+        ex.Message.Should().Contain("q1").And.Contain("(unknown)");
+    }
 }

--- a/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
+++ b/tests/Tapestry.Server.Tests/Modules/QuestScriptCoverageVerifierTests.cs
@@ -103,4 +103,32 @@ public class QuestScriptCoverageVerifierTests : IDisposable
         var act = () => verifier.Verify();
         act.Should().NotThrow("a validation: lenient pack warns on a missing script: instead of failing the boot");
     }
+
+    [Fact]
+    public void UncoveredScript_LenientPack_DoesNotThrow()
+    {
+        WriteScriptFile("quests/q1.js"); // exists, not marked executed
+        var quests = new QuestRegistry();
+        quests.Register(new QuestDefinition { Id = "q1", Script = "quests/q1.js", PackDirectory = _packDir });
+        var rt = BuildRuntime();
+        var verifier = BuildVerifier(quests, rt, validation: "lenient");
+
+        var act = () => verifier.Verify();
+        act.Should().NotThrow("a validation: lenient pack warns instead of failing the boot");
+    }
+
+    [Fact]
+    public void CoveredScript_DoesNotThrow()
+    {
+        var path = WriteScriptFile("quests/q1.js");
+        var quests = new QuestRegistry();
+        quests.Register(new QuestDefinition { Id = "q1", Script = "quests/q1.js", PackDirectory = _packDir });
+        var rt = BuildRuntime();
+        rt.MarkFileExecuted(path); // simulate the scripts glob having loaded it
+
+        var verifier = BuildVerifier(quests, rt, validation: "strict");
+
+        var act = () => verifier.Verify();
+        act.Should().NotThrow("the glob already loaded the file -- this is the trolloc-slayer shape");
+    }
 }


### PR DESCRIPTION
## Summary

The pack `scripts:` glob is now the **single** executor of quest JS. Previously a second executor in `QuestStartupModule` ran the quest `script:` field via the unattributed `JintRuntime.Execute(string)` overload, so on the glob-uncovered path `registerScript` recorded a **stale/blank owner** (broken collision messages, unresolvable `{override:true}` edge checks, hooks invoked as the wrong pack).

- **New `QuestScriptCoverageVerifier`** — for each quest carrying a `script:` field, if the file is missing-on-disk **or** present-but-never-loaded-by-the-glob, its hooks can never bind. Resolves the owning pack via `IPackManifestProvider` and **throws** (strict pack, the default) or **warns** (`validation: lenient` pack) — mirroring `PackValidator`'s strict/lenient + missing-manifest-defaults-to-strict convention.
- **`QuestStartupModule`** stops executing quest scripts: it calls `_coverageVerifier.Verify()` then starts persistence + the objective watcher. The old executor and its `QuestRegistry`/`JintRuntime`/`ILogger` deps are deleted (-45 LOC).
- **Attribution hole closed transitively** — with only the attributed glob executing, `registerScript` always reads the correct `__currentPack`. Pinned by `RegisterScript_ViaGlobPath_RecordsRealOwner` + an `internal OwnerOf` accessor.
- The quest `script:` field is **retained** on `QuestDefinition` (YAML parse-compat) but no longer drives loading. `JintRuntime.MarkFileExecuted`'s ledger is now the coverage source of truth (doc refreshed; behavior/signature unchanged). The bare `Execute(string)` overload is now tests-only and doc-warned against pack use.

Out of scope (intentionally): quest-hook stays single-winner; additive event-shaped subscriptions are a separate design.

Spec + plan: rocky `docs/tapestry/superpowers/{specs,plans}/2026-06-10-quest-script-loader-unification*`.

## Test Plan

- [x] Full build clean (warnings-as-errors, 0 warnings)
- [x] Full suite: **2303 tests, 0 failures** (incl. verifier matrix: uncovered/missing x strict-throw/lenient-warn, covered-ok, no-manifest defaults-strict, glob-path owner attribution)
- [x] Strict-boot against the `@mallek/legends-forgotten` trolloc-slayer corpus (the only real quest `script:`, glob-covered): clean boot, QuestStartup configured, pack validation 0 issues, game loop started, **no false coverage throw**
- [x] Telnet scenario suite: 10/10 passed
- [ ] CI gated pipeline (test -> strict-boot -> scenarios) green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)