### PR TITLE
deps: bump Microsoft.Extensions.* family to 10.0.9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,11 +8,11 @@
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="Jint" Version="4.9.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />


### PR DESCRIPTION
Bumps the five `Microsoft.Extensions.*` packages from 10.0.5 to 10.0.9 in one atomic commit via `Directory.Packages.props` (Central Package Management).

## Why one PR instead of dependabot's four

Dependabot split this family across four PRs (#112, #113, #114, #115) that fight each other. The runtime packages (`DependencyInjection`, `Logging`) and their `*.Abstractions` siblings were split into separate PRs, so neither half was mergeable alone. #114 failed with `NU1605: Detected package downgrade: Microsoft.Extensions.Logging.Abstractions from 10.0.9 to 10.0.5` because `Logging` 10.0.9 transitively requires `Logging.Abstractions >= 10.0.9`, but that bump lived in #115. #113 was stale (claimed a 10.0.8 baseline that never existed on master).

These packages move in lockstep, so they belong in one PR. This bumps all five together.

Closes #112, #113, #114, #115.

## Verification

`dotnet test Tapestry.slnx` locally: clean restore (no NU1605), all tests pass.
- Tapestry.Engine.Tests: 1669 passed
- Tapestry.Scripting.Tests: 564 passed
- Tapestry.Server.Tests: 74 passed
- Tapestry.Networking.Tests: 80 passed
