### PR TITLE
ci: group dependabot updates by package family

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,24 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry*"
+      serilog:
+        patterns:
+          - "Serilog*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
Adds `groups:` blocks to `.github/dependabot.yml` so interdependent package families travel in a single PR instead of being split across overlapping ones.

## Why

#112-#115 were a self-inflicted deadlock: with no grouping config, dependabot's resolver auto-bundled `Microsoft.Extensions.*` packages by immediate constraint edges and guessed wrong, splitting `Logging` from `Logging.Abstractions` across separate PRs. Under Central Package Management with warnings-as-errors that's an instant `NU1605` downgrade error - neither half is mergeable alone.

Declaring the family as an explicit group removes the guessing: dependabot bundles the whole family or nothing.

## Groups added

- **microsoft-extensions** - `Microsoft.Extensions.*` (5 packages, track the .NET 10 runtime, move in lockstep)
- **opentelemetry** - `OpenTelemetry*` (4 packages)
- **serilog** - `Serilog*` (5 packages)
- **actions** - all github-actions bumps in one weekly PR

Docker is left ungrouped (single image).

## Notes

Grouping applies to PRs created after this lands - it does not retroactively merge existing ones. No code change, config only.
